### PR TITLE
added design token types

### DIFF
--- a/src/_create-props.js
+++ b/src/_create-props.js
@@ -58,6 +58,44 @@ const jsonbundle = {
 }
 const designtokens = Object.entries(jsonbundle).map(([key, token]) => {
   return [key, {
+    "Majestic magenta": {
+      "value": "#ff00ff",
+      "type": "color"
+    },
+    "Translucent shadow": {
+      "value": "#00000088",
+      "type": "color"
+    },
+    "Primary font": {
+      "value": "Comic Sans MS",
+      "type": "font"
+    },
+    "Body font": {
+      "value": ["Helvetica", "Arial"],
+      "type": "font"
+    },
+    "my types": {
+      "color pair": {
+        "type": "typedef",
+        "value": {
+          "foreground": {
+            "type": "color",
+            "required": true
+          },
+          "background": {
+            "type": "color",
+            "required": true
+          }
+        }
+      }
+    },
+    "broken-token": {
+      "type": "{my types.color pair}",
+      "value": {
+        "foreground": "Comic Sans MS",
+        "background": "#eeeeee"
+      }
+    },
     value: token
   }]
 })


### PR DESCRIPTION
Issue related: #111 
Please find some examples inputted to represent the values. Also, let me know if it is the correct implementation of colour types. So, I will add more design tokens to this pull request before merging it into the final project.
Examples of design tokens:
```
"Majestic magenta": {
      "value": "#ff00ff",
      "type": "color"
    },
    "Translucent shadow": {
      "value": "#00000088",
      "type": "color"
    },
```