### PR TITLE
fix subheading background gradient

### DIFF
--- a/docsite/index.css
+++ b/docsite/index.css
@@ -215,7 +215,7 @@ section.hero {
   & > * {
     --op-gradient-direction: to right;
     background: var(--gradient-1) fixed;
-    background-size: 12ch 50%;
+    background-size: 13ch 50%;
     -webkit-background-clip: text;
     -webkit-text-fill-color: transparent;
 


### PR DESCRIPTION
The last characters look a bit off here unless it is intended
![image](https://user-images.githubusercontent.com/8033084/146684985-f9b4f0f3-c228-4c49-9bc0-1623471a3946.png)

The fix would look like this
![image](https://user-images.githubusercontent.com/8033084/146684998-46216b80-0dc3-4b88-9da1-f5b75a9412d5.png)

Dark mode looks good either way.
