### PR TITLE
Updating tabindex selector to exclude negative values

### DIFF
--- a/src/extra/normalize.css
+++ b/src/extra/normalize.css
@@ -66,7 +66,7 @@
   text-underline-offset: 1px;
 }
 
-:where(a[href], area, button, input, label[for], select, summary, textarea, [tabindex]) {
+:where(a[href], area, button, input, label[for], select, summary, textarea, [tabindex]:not([tabindex*="-"])) {
   cursor: pointer;
   touch-action: manipulation;
 }


### PR DESCRIPTION
Updating tabindex in `normalize.css` to exclude negative values.
Issue #133 