### PR TITLE
adding backgrounds to 'why' section icons

### DIFF
--- a/docsite/index.css
+++ b/docsite/index.css
@@ -894,18 +894,38 @@ pre[class*="language-"] {
   & > div:nth-of-type(1) svg { 
     color: var(--grape-5);
     border-color: var(--grape-3);
+    background-color: var(--grape-0);
+    @nest [data-theme="dark"] & {
+      color: var(--grape-0);
+      background-color: var(--grape-7)
+    }
   }
   & > div:nth-of-type(2) svg { 
     color: var(--orange-5);
     border-color: var(--orange-3);
+    background-color: var(--orange-0);
+    @nest [data-theme="dark"] & {
+      color: var(--orange-0);
+      background-color: var(--orange-7)
+    }
   }
   & > div:nth-of-type(3) svg { 
     color: var(--indigo-5);
     border-color: var(--indigo-3);
+    background-color: var(--indigo-0);
+    @nest [data-theme="dark"] & {
+      color: var(--indigo-0);
+      background-color: var(--indigo-7)
+    }
   }
   & > div:nth-of-type(4) svg { 
     color: var(--red-5);
     border-color: var(--red-3);
+    background-color: var(--red-0);
+    @nest [data-theme="dark"] & {
+      color: var(--red-0);
+      background-color: var(--red-7)
+    }
   }
 
   & svg {


### PR DESCRIPTION
Light mode
![image](https://user-images.githubusercontent.com/8033084/147106795-28a8c8fb-516d-416d-bb71-8605fad91fe1.png)

Dark Mode
![image](https://user-images.githubusercontent.com/8033084/147106917-ac0abf48-b63f-4fea-8150-1b572b70e45b.png)
