### PR TITLE
Update color swatches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 dist/
 .cache/
 node_modules/
+.vscode/

--- a/docsite/index.css
+++ b/docsite/index.css
@@ -443,7 +443,7 @@ pre[class*="language-"] {
 
   & > h4 {
     counter-reset: basic -1;
-    font-size: var(--fontsize-fluid-1);
+    font-size: var(--font-size-fluid-1);
     font-weight: var(--font-weight-5);
     width: var(--size-10);
   }

--- a/docsite/index.css
+++ b/docsite/index.css
@@ -508,8 +508,8 @@ pre[class*="language-"] {
 }
 
 .color-swatch {
-  --size: var(--size-5);
-  border-radius: var(--radius-round);
+  --size: var(--size-7);
+  border-radius: var(--radius-1);
   box-shadow: var(--inner-shadow-0);
   inline-size: 7%;
   block-size: var(--size);

--- a/docsite/index.css
+++ b/docsite/index.css
@@ -442,10 +442,17 @@ pre[class*="language-"] {
 
   & > h4 {
     counter-reset: basic -1;
+    font-size: var(--fontsize-fluid-1);
+    font-weight: var(--font-weight-5);
+    width: var(--size-10);
   }
 
   & > h4::before {
     display: none;
+  }
+  
+  @media (--md-n-below) {
+    gap: var(--size-1);
   }
 }
 

--- a/docsite/index.css
+++ b/docsite/index.css
@@ -438,7 +438,8 @@ pre[class*="language-"] {
 .open-colors {
   display: flex;
   align-items: center;
-  gap: var(--size-2);
+  gap: var(--size-3);
+  padding-block: var(--size-2);
 
   & > h4 {
     counter-reset: basic -1;
@@ -527,7 +528,8 @@ pre[class*="language-"] {
   }
 
   &:is(:hover,:focus) {
-    transform: scale(1.5);
+    cursor: pointer;
+    transform: scale(1.15);
     transition-delay: 0s;
     transition-timing-function: var(--ease-elastic-3);
 
@@ -546,9 +548,7 @@ pre[class*="language-"] {
 
   @media (--md-n-below) {
     --size: var(--size-3);
-  }
-  @media (--xs-n-below) {
-    --size: var(--size-2);
+    inline-size: var(--size-6);
   }
 }
 
@@ -1036,6 +1036,9 @@ pre[class*="language-"] {
       font-size: var(--font-size-3);
     }
   }
+}
+#colors {
+  width: 100%;
 }
 
 #colors details h3 {

--- a/docsite/index.html
+++ b/docsite/index.html
@@ -884,6 +884,7 @@
         </div>
       </div>
       <article class="just-stretch">
+        <h3>Color Palette</h3>
         <div class="open-colors count-em">
           <h4>Gray</h4>
           <span class="color-swatch" style="background-color: var(--gray-0)"></span>


### PR DESCRIPTION
Trying to address https://github.com/argyleink/open-props/issues/115

Proposed Changes:
- Fix layout shift by setting colors width to 100%.
- Fix swatch visibility on resize.
- Make swatch rectangular.
- Keep Existing behaviour of showing number on hover.

https://user-images.githubusercontent.com/11358903/147774803-e8b5ddb9-ec3f-438a-bfdd-6c1d2dff2a9a.mp4

@argyleink Let me know your thoughts on this. 

