### PR TITLE
Bugfix/responsiveness site

### DIFF
--- a/docsite/index.css
+++ b/docsite/index.css
@@ -1490,6 +1490,7 @@ input[type="range"] {
 }
 
 #npm > pre, #cli > pre {
+  max-inline-size: var(--max-inline-body);
   margin: 0;
 }
 

--- a/docsite/index.css
+++ b/docsite/index.css
@@ -109,7 +109,7 @@ nav {
   }
 
   & > a[href="#getting-started"] {
-    @media (--xs-n-below) {
+    @media (--sm-n-below) {
       display: none;
     }
   }

--- a/docsite/index.css
+++ b/docsite/index.css
@@ -1490,8 +1490,7 @@ input[type="range"] {
 }
 
 #npm > pre, #cli > pre {
-  max-inline-size: var(--max-inline-body);
-  margin: 0;
+  margin-block: 0;
 }
 
 .license {


### PR DESCRIPTION
This fixes the issue #141,
by making sure the `<pre>` tags on the getting started section do not cause an overflow on smaller screens.
And also fixed the page header nav overflow, by setting the media query a little higher.

![Screenshot 2022-01-02 at 13 10 13](https://user-images.githubusercontent.com/4387541/147875335-6fb817ff-ff86-41a3-80f2-e75d174f9896.jpg)

Closes #141 