### PR TITLE
generate JSON for figma-tokens plugin to use

### DIFF
--- a/src/_create-props.js
+++ b/src/_create-props.js
@@ -116,6 +116,11 @@ Object.entries(jsonbundle).map(([key, token]) => {
 const FigmaTokens = fs.createWriteStream('../open-props.figma-tokens.json')
 FigmaTokens.end(JSON.stringify(figmatokens, null, 2))
 
+const figmatokensSYNC = { 'open-props': { ...figmatokens } }
+
+const FigmaTokensSync = fs.createWriteStream('../open-props.figma-tokens.sync.json')
+FigmaTokensSync.end(JSON.stringify(figmatokensSYNC, null, 2))
+
 const buildPropsStylesheet = ({filename, props}) => {
   const file = fs.createWriteStream(filename)
 

--- a/src/_create-props.js
+++ b/src/_create-props.js
@@ -77,6 +77,45 @@ const designtokens = Object.entries(jsonbundle).map(([key, token]) => {
 const JSONtokens = fs.createWriteStream('../open-props.tokens.json')
 JSONtokens.end(JSON.stringify(Object.fromEntries(designtokens), null, 2))
 
+const figmatokens = {};
+
+Object.entries(jsonbundle).map(([key, token]) => {
+  let meta = {}
+
+  let isLength = key.includes('size') && !key.includes('border-size')
+  let isBorder = key.includes('border-size')
+  let isRadius = key.includes('radius')
+  let isShadow = key.includes('shadow')
+  let colors = ['gray','red','pink','grape','violet','indigo','blue','cyan','teal','green','lime','yellow','orange']
+  let isColor = colors.some(color => key.includes(color))
+  
+  if      (isLength) meta.type = 'sizing'
+  else if (isBorder) meta.type = 'borderWidth'
+  else if (isRadius) meta.type = 'borderRadius'
+  else if (isShadow) meta.type = 'boxShadow'
+  else if (isColor)  meta.type = 'color'
+  else               meta.type = 'other'
+
+  if (!(meta.type in figmatokens)) figmatokens[meta.type] = {}
+  
+  if (isColor) {
+    let color = /--(.+?)-/.exec(key)[1]
+    if (!(color in figmatokens[meta.type])) figmatokens[meta.type][color] = {}
+    figmatokens[meta.type][color][key] = {
+      value: token,
+      ...meta,
+    }
+  } else {
+    figmatokens[meta.type][key] = {
+      value: token,
+      ...meta,
+    }
+  }
+})
+
+const FigmaTokens = fs.createWriteStream('../open-props.figma-tokens.json')
+FigmaTokens.end(JSON.stringify(figmatokens, null, 2))
+
 const buildPropsStylesheet = ({filename, props}) => {
   const file = fs.createWriteStream(filename)
 


### PR DESCRIPTION
for #21

<img width="939" alt="partly set up figma tokens" src="https://user-images.githubusercontent.com/18131787/148630676-0636c161-990c-497a-8087-3bd093e7b04a.png">

@argyleink, feel free to suggest changes! (especially for the "other" group - figma-tokens recognizes only certain names for the top-level groupings in the JSON)

I kinda like having the token names the same as the CSS variables
