### PR TITLE
remove vertical-align as it doesn't apply on display: block-elements

### DIFF
--- a/src/extra/normalize.css
+++ b/src/extra/normalize.css
@@ -99,7 +99,6 @@
 
 :where(img, svg, video, canvas, audio, iframe, embed, object) {
   display: block;
-  vertical-align: middle;
 }
 
 :where(img, svg, video) {


### PR DESCRIPTION
f.e. mdn says on https://developer.mozilla.org/en-US/docs/Web/CSS/vertical-align:
`Note that vertical-align only applies to inline, inline-block and table-cell elements: you can't use it to vertically align block-level elements.`