### PR TITLE
docs: update colors-hsl usage 

### DIFF
--- a/docsite/index.html
+++ b/docsite/index.html
@@ -1009,7 +1009,7 @@
             @import "open-props/colors-hsl";
 
             .backdrop {
-              background-color: hsl(var(--gray-9) / 30%);
+              background-color: hsl(var(--gray-9-hsl) / 30%);
             }
           </code></pre>
         </div>


### PR DESCRIPTION
Update colors-hsl usage in the **Modify Opacity Example**.

Also, it looks like `colors-hsl` is not included in `open-props.min.css`. Not sure if that's intentional.

