### PR TITLE
DOCS: Fix counters in Firefox

### DIFF
--- a/docsite/index.css
+++ b/docsite/index.css
@@ -1215,7 +1215,7 @@ pre[class*="language-"] {
 }
 
 .count-em {
-  counter-reset: basic;
+  counter-set: basic;
 
   & > *::before {
     counter-increment: basic;

--- a/docsite/index.css
+++ b/docsite/index.css
@@ -1218,7 +1218,9 @@ pre[class*="language-"] {
 
   &::before {
   content: '';
-  counter-reset: basic;}
+  counter-reset: basic;
+  position: absolute;
+}
 
   & > *::before {
     counter-increment: basic;

--- a/docsite/index.css
+++ b/docsite/index.css
@@ -1216,7 +1216,8 @@ pre[class*="language-"] {
 
 .count-em {
 
-  &::before{
+  &::before {
+  content: '';
   counter-reset: basic;}
 
   & > *::before {

--- a/docsite/index.css
+++ b/docsite/index.css
@@ -1215,7 +1215,9 @@ pre[class*="language-"] {
 }
 
 .count-em {
-  counter-set: basic;
+
+  &::before{
+  counter-reset: basic;}
 
   & > *::before {
     counter-increment: basic;


### PR DESCRIPTION
Firefox doesn't properly support `counter-reset` if the parent also uses counter-reset for the same counter.
(oddly enough, it does reset it for that individual element, but not the other elements using the same counter).

This has an impact on the colors section, which resets the counter on the `h4`s. When you hover on them in FF, because the reset wasn't carrying over, the numbering goes from 1 to 10, rather than 0 to 9.

![open-prop-wrong-numbers](https://user-images.githubusercontent.com/25749407/152022071-e2d0134c-7481-421b-a52d-5a5c8f307e37.gif)

Firefox would work with a `counter-set`, rather than `counter-reset` on the parent, but atm it's not supported in Safari, so this is a bit of a workaround using a pseudo-element on `.count-em` to reset it instead since Firefox is fine with different siblings resetting the same counter.

This `::before` caused some layout issues anywhere `count-em` was used to show layout classes, such as sizes, which is why the `position: absolute` has also been added.

You can see all three approaches in this [very simple example in this codepen](https://codepen.io/kevinpowell/pen/bGYpwgX), with the first example not properly resetting if viewed in Firefox.