### PR TITLE
Fix typo

### DIFF
--- a/docsite/index.html
+++ b/docsite/index.html
@@ -1889,7 +1889,7 @@
               --ease-{1-5}
               --ease-in-{1-5}
               --ease-out-{1-5}
-              --ease-inout-{1-5}
+              --ease-in-out-{1-5}
               --ease-elastic-{1-5}
               --ease-squish-{1-5}
               --ease-step-{1-5}


### PR DESCRIPTION
In the examples of the easing props `--ease-in-out-{1-5}` was written as `--ease-inout-{1-5}`. This fixes the typo.