### PR TITLE
@parcel/css-cli to replace postcss build commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
     "gen:op": "cd build && node props.js '' true",
     "gen:nowhere": "cd build && node props.js '' false",
     "gen:prefixed": "cd build && node props.js 'op'",
+    "parcel": "parcel-css --bundle --custom-media --nesting --minify -t 'last 2 versions' src/index.css -o docsite/parcel.css",
     "lib:js": "npm run bundle:pre-edit && microbundle --no-sourcemap && npm run bundle:post-edit",
     "lib:all": "postcss src/index.css -o open-props.min.css",
     "lib:normalize": "postcss src/extra/normalize.css -o normalize.min.css",
@@ -143,16 +144,11 @@
     "lib:colors:orange-hsl": "postcss src/props.orange-hsl.css -o orange-hsl.min.css"
   },
   "devDependencies": {
+    "@parcel/css-cli": "^1.3.1",
     "ava": "^3.15.0",
     "concurrently": "^6.2.1",
-    "cssnano": "^5.0.8",
     "json": "^11.0.0",
     "microbundle": "^0.13.3",
-    "open-color": "^1.9.1",
-    "postcss": "^8.3.9",
-    "postcss-cli": "^8.3.1",
-    "postcss-combine-duplicated-selectors": "^10.0.3",
-    "postcss-import": "^14.0.2",
-    "postcss-preset-env": "6.7.x"
+    "open-color": "^1.9.1"
   }
 }


### PR DESCRIPTION
todo
- [ ] move the poc command line added to package.json to all the postcss commands
- [ ] test before and after filesizes (for funsies)
- [ ] test and inspect all output to ensure no regressions
- [ ] determine how to, or if OP continues to, combine selectors

this proves the groundwork though, and given the output is smaller, than this PR is a go 👍🏻 