### PR TITLE
Fix build on windows devices

### DIFF
--- a/build/props.js
+++ b/build/props.js
@@ -18,7 +18,14 @@ import {toJSON} from './to-json.js'
 import {toTokens} from './to-tokens.js'
 import {toFigmaTokens} from './to-figmatokens.js'
 
-const [,,prefix,useWhere] = process.argv
+let prefix = process.argv[2];
+const useWhere = process.argv[3]
+
+// On windows devices the prefixs is "''" if not set
+if(prefix === "''") {
+  prefix = undefined;
+}
+
 const selector = useWhere === 'true' ? ':where(html)' : 'html'
 
 const mainbundle = {

--- a/build/props.js
+++ b/build/props.js
@@ -18,13 +18,7 @@ import {toJSON} from './to-json.js'
 import {toTokens} from './to-tokens.js'
 import {toFigmaTokens} from './to-figmatokens.js'
 
-let prefix = process.argv[2];
-const useWhere = process.argv[3]
-
-// On windows devices the prefixs is "''" if not set
-if(prefix === "''") {
-  prefix = undefined;
-}
+const [,,prefix='',useWhere] = process.argv
 
 const selector = useWhere === 'true' ? ':where(html)' : 'html'
 

--- a/build/to-stylesheet.js
+++ b/build/to-stylesheet.js
@@ -14,7 +14,7 @@ export const buildPropsStylesheet = ({filename,props}, {selector,prefix}) => {
     if (prop.includes('-@'))
       return
 
-    if (prefix)
+    if (prefix && prefix !== "''")
       prop = `--${prefix}-` + prop.slice(2)
     
     if (prop.includes('animation')) {


### PR DESCRIPTION
Fix build on windows devices by manually setting undefined for a not defined prefix.