### PR TITLE
fix prefers-contrast to draft spec

### DIFF
--- a/src/props.media.css
+++ b/src/props.media.css
@@ -8,8 +8,8 @@
 @custom-media --OSdark        (prefers-color-scheme: dark);
 @custom-media --OSlight       (prefers-color-scheme: light);
 
-@custom-media --highContrast  (prefers-contrast: high);
-@custom-media --lowContrast   (prefers-contrast: low);
+@custom-media --highContrast  (prefers-contrast: more);
+@custom-media --lowContrast   (prefers-contrast: less);
 
 @custom-media --portrait      (orientation: portrait);
 @custom-media --landscape     (orientation: landscape);


### PR DESCRIPTION
Found that the prefers-contrast prop in the media queries look like it should be: more | less not high | low
checked the w3c spec and MDN

https://drafts.csswg.org/mediaqueries-5/Overview.bs

https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-contrast 

and a demo from a link in discord https://codepen.io/argyleink/pen/RwgzJXV

