### PR TITLE
feat: Expose TypeScript declarations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "open-props",
-  "version": "1.3.12",
+  "version": "1.3.16",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "open-props",
-      "version": "1.3.12",
+      "version": "1.3.16",
       "license": "MIT",
       "devDependencies": {
         "ava": "^3.15.0",
@@ -19,7 +19,8 @@
         "postcss-cli": "^8.3.1",
         "postcss-combine-duplicated-selectors": "^10.0.3",
         "postcss-import": "^14.0.2",
-        "postcss-preset-env": "6.7.x"
+        "postcss-preset-env": "6.7.x",
+        "type-fest": "^2.12.2"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -7508,6 +7509,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/read-pkg/node_modules/type-fest": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
+      "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/readable-stream": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
@@ -8557,12 +8567,15 @@
       "dev": true
     },
     "node_modules/type-fest": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
-      "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.12.2.tgz",
+      "integrity": "sha512-qt6ylCGpLjZ7AaODxbpyBZSs9fCI9SkL3Z9q2oxMBQhs/uyY+VD8jHA8ULCGmWQJlBgqvO3EJeAngOHD8zQCrQ==",
       "dev": true,
       "engines": {
-        "node": ">=8"
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/typedarray-to-buffer": {
@@ -14907,6 +14920,14 @@
         "normalize-package-data": "^2.5.0",
         "parse-json": "^5.0.0",
         "type-fest": "^0.6.0"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
+          "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
+          "dev": true
+        }
       }
     },
     "readable-stream": {
@@ -15754,9 +15775,9 @@
       "dev": true
     },
     "type-fest": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
-      "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.12.2.tgz",
+      "integrity": "sha512-qt6ylCGpLjZ7AaODxbpyBZSs9fCI9SkL3Z9q2oxMBQhs/uyY+VD8jHA8ULCGmWQJlBgqvO3EJeAngOHD8zQCrQ==",
       "dev": true
     },
     "typedarray-to-buffer": {

--- a/package.json
+++ b/package.json
@@ -20,10 +20,12 @@
   "main": "dist/open-props.cjs",
   "unpkg": "open-props.min.css",
   "module": "dist/open-props.module.js",
+  "types": "dist/types/index.d.ts",
   "exports": {
     ".": {
       "import": "./dist/open-props.module.js",
       "require": "./dist/open-props.cjs",
+      "types": "./dist/types/index.d.ts",
       "default": "./dist/open-props.cjs"
     },
     "./src": "./src/index.js",
@@ -153,6 +155,7 @@
     "postcss-cli": "^8.3.1",
     "postcss-combine-duplicated-selectors": "^10.0.3",
     "postcss-import": "^14.0.2",
-    "postcss-preset-env": "6.7.x"
+    "postcss-preset-env": "6.7.x",
+    "type-fest": "^2.12.2"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -11,8 +11,10 @@ import Shadows from './props.shadows.js'
 import SVG from './props.svg.js'
 import Zindex from './props.zindex.js'
 
-const camelCase = (text) => {
-  text = text.replace(/[-]+(.)?/g, (_, c) => (c ? c.toUpperCase() : ''))
+const camelize = text => {
+  text = text.replace(/[-]+(.)?/g, (_, c) => c 
+    ? c.toUpperCase() 
+    : '')
   return text.substr(0, 1).toLowerCase() + text.substr(1)
 }
 
@@ -22,7 +24,8 @@ const camelCase = (text) => {
  * @returns {import("type-fest").CamelCasedPropertiesDeep<T>}
  */
 const keysToCamelCase = (props) => {
-  for (var prop in props) props[camelCase(prop)] = props[prop]
+  for (var prop in props)
+    props[camelize(prop)] = props[prop]
   return props
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -21,7 +21,7 @@ const camelize = text => {
 /**
  * @template T
  * @param {T} props
- * @returns {import("type-fest").CamelCasedPropertiesDeep<T>}
+ * @returns {T & import("type-fest").CamelCasedPropertiesDeep<T>}
  */
 const keysToCamelCase = (props) => {
   for (var prop in props)

--- a/src/index.js
+++ b/src/index.js
@@ -11,20 +11,22 @@ import Shadows from './props.shadows.js'
 import SVG from './props.svg.js'
 import Zindex from './props.zindex.js'
 
-const camelize = text => {
-  text = text.replace(/[-]+(.)?/g, (_, c) => c 
-    ? c.toUpperCase() 
-    : '')
+const camelCase = (text) => {
+  text = text.replace(/[-]+(.)?/g, (_, c) => (c ? c.toUpperCase() : ''))
   return text.substr(0, 1).toLowerCase() + text.substr(1)
 }
 
-const mapToObjectNotation = props => {
-  for (var prop in props)
-    props[camelize(prop)] = props[prop]
+/**
+ * @template T
+ * @param {T} props
+ * @returns {import("type-fest").CamelCasedPropertiesDeep<T>}
+ */
+const keysToCamelCase = (props) => {
+  for (var prop in props) props[camelCase(prop)] = props[prop]
   return props
 }
 
-const OpenProps = mapToObjectNotation({
+const OpenProps = keysToCamelCase({
   ...Animations,
   ...Sizes,
   ...Colors,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "rootDir": "src",
+    "declarationDir": "dist/types",
+    "allowJs": true,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "esModuleInterop": true
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
**Do not merge:** See `TODO` section below

This PR updates the `lib:js` build to additionally output TypeScript declarations. [Microbundle](https://www.npmjs.com/package/microbundle) already handles TypeScript projects with zero config and thus only a few tweaks were needed to emit declaration files:
- Added a `tsconfig.json` defining the `dist/types` output directory
- Updated the `package.json` `"types":` and `"exports.types":` keys to resolve the emitted `dist/types/index.d.ts`
- Added the [type-fest](https://github.com/sindresorhus/type-fest) (TypeScript utility types package) as a dev dependency to address the `any` types in the `src/index.js` default export
- Added a `JSDoc` annotation to help `tsc` understand the camel case keys transform on the default export

#### After running `npm run lib:js`
![image](https://user-images.githubusercontent.com/32409546/163601990-679ef59a-5d06-424a-abfa-c20982d23770.png)


#### Example `npm link`ing and using the intellisense in a `.mjs` file
![image](https://user-images.githubusercontent.com/32409546/163601879-3d1a31c5-5d6a-4f83-8993-6a547ce715dd.png)

### Important

There is still one issue I haven't resolved and that is that the declarations in `.cjs` modules want to resolve values off `OpenProps.default`:
![image](https://user-images.githubusercontent.com/32409546/163602503-706ea08c-da45-4edb-8ff3-61682a264e8d.png)

TODO:
- [ ] - Debug why `.cjs` files think props are accessible from `OpenProps.default`
- [ ] - Take a second pass at the `tsconfig` `compilerOptions` and ensure the appropriate defaults have been set