### PR TITLE
Add unnecessary config files to the `.npmignore` & change logo alt text

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,6 @@
 .firebaserc
 .github
+firebase.json
+postcss.config.js
 docsite/
 test/

--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,5 @@
 .firebaserc
 .github
 firebase.json
-postcss.config.cjs
 docsite/
 test/

--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,6 @@
 .firebaserc
 .github
 firebase.json
-postcss.config.js
+postcss.config.cjs
 docsite/
 test/

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 <div align="center">
   
-![Frame 2](https://user-images.githubusercontent.com/1134620/141246730-7df4cf2a-6249-42ca-a01b-494c3ccddabe.png)
+![Open Props Logo](https://user-images.githubusercontent.com/1134620/141246730-7df4cf2a-6249-42ca-a01b-494c3ccddabe.png)
 
 ## Open Source CSS Variables
   


### PR DESCRIPTION
## In this pull Request

> Based on [comment](https://github.com/argyleink/open-props/pull/224#issuecomment-1101564351) 

- [x] Added `firebase.json`and `postcss.config.js` to the `.npmignore` file
- [x] Change the `alt` text to the Open Props logo in the readme file 