### PR TITLE
scrollthumb updates

### DIFF
--- a/src/extra/brand.css
+++ b/src/extra/brand.css
@@ -1,13 +1,13 @@
 @import "theme.css";
 
 :where(html) {
-  --scrollbar-color: var(--gray-7);
+  --scrollthumb-color: var(--gray-6);
 
-  scrollbar-color: var(--scrollbar-color) transparent;
+  scrollbar-color: var(--scrollthumb-color) transparent;
   accent-color: var(--link);
   caret-color: var(--link);
 
   @media (--OSlight) {
-    --scrollbar-color: var(--gray-4);
+    --scrollthumb-color: var(--gray-7);
   }
 }


### PR DESCRIPTION
Fixes #229: 
* renamed `--scrollbar-color` to `--scrollthumb-color`
* set grays that pass WCAG AA contrast ratios against surfaces in dark and light modes

## `/docsite` on http://localhost:3000/ in Dark Mode:
<img width="1280" alt="dark" src="https://user-images.githubusercontent.com/18131787/176987797-f449a1d5-5262-466c-b3c6-62d73e0ee3fc.png">

## `/docsite` on http://localhost:3000/ in Light Mode:
<img width="1276" alt="light" src="https://user-images.githubusercontent.com/18131787/176987800-c25b1a73-f389-4ce6-8a11-c40233781d25.png">

