### PR TITLE
Fix #278 and extend with --firefoxMacONLY, --chromiumONLY, --webkitONLY

### DIFF
--- a/src/props.supports.css
+++ b/src/props.supports.css
@@ -1,6 +1,9 @@
-@custom-media --safariONLY  (-webkit-hyphens: none);
-@custom-media --firefoxONLY (-moz-appearance: none);
-@custom-media --chromeONLY  (-webkit-tap-highlight-color: black);
+@custom-media --safariONLY      (-apple-pay-button-style: inherit);
+@custom-media --firefoxONLY     (-moz-appearance: inherit);
+@custom-media --firefoxMacONLY  (-moz-osx-font-smoothing: inherit);
+@custom-media --chromeONLY      (-webkit-app-region: inherit) and (not (container-type: none));
+@custom-media --chromiumONLY    (-webkit-app-region: inherit) and (container-type: none);
+@custom-media --webkitONLY      (alt: inherit) and (not (-apple-pay-button-style: inherit))
 
 :where(html) {
   --isLTR: 1;


### PR DESCRIPTION
Test page and explainer https://codepen.io/WebMechanic/pen/poVexYp?editors=1100

Sources: 
- WebKit https://webkit.org/css-status/#?status=non-standard
- Lea Verou's https://css3test.com/  "Experimental" filter
- https://github.com/fingerprintjs/blog-nojs-fingerprint-demo/

`container-type:`**`none`** is a non-standard value to test against. It **must not** be changed to `inherit` which is usually sufficient and safe to check property support.