### PR TITLE
docs: update pos-css link with new repo

### DIFF
--- a/docsite/index.html
+++ b/docsite/index.html
@@ -2886,7 +2886,7 @@
       <header class="just-for-gap">
         <h2>Media Queries</h2>
         <div class="block-wrap">
-          <p>Currently one step ahead of <a href="https://drafts.csswg.org/mediaqueries-5/#at-ruledef-custom-media">the CSS spec</a>, Open Props offers named media queries with the <code>@custom-media</code> syntax. Available only with <a href="https://github.com/postcss/postcss-custom-media">this PostCSS plugin</a>, for now 😈</p>
+          <p>Currently one step ahead of <a href="https://drafts.csswg.org/mediaqueries-5/#at-ruledef-custom-media">the CSS spec</a>, Open Props offers named media queries with the <code>@custom-media</code> syntax. Available only with <a href="https://github.com/csstools/postcss-plugins/tree/main/plugins/postcss-custom-media">this PostCSS plugin</a>, for now 😈</p>
 
           <blockquote class="icon-quote indigo">
             <svg viewBox="0 0 24 24">


### PR DESCRIPTION
The post-css plugin has moved on to a different repo as announced [here](https://github.com/csstools/postcss-plugins/discussions/75).
This PR will use the new link to the post-css plugin that is needed for open-props.


