### PR TITLE
Update VScode instructions

### DIFF
--- a/docsite/index.html
+++ b/docsite/index.html
@@ -1088,7 +1088,7 @@
             <ol>
               <li>
                 VScode has an intellisense feature which you can tap into,
-                by passing the path to the <code>node_modules</code> folder when
+                by passing the path to the <code>node_modules</code> folder where
                 open-props is installed
               </li>
               <li>
@@ -1123,7 +1123,7 @@
 
                   // add support for autocomplete in JS or JS like files
                   "cssvar.extensions": [
-                    "css", "html", "jsx", "tsx"
+                    "css", "jsx", "tsx"
                   ]
                 }
               </code></pre>


### PR DESCRIPTION
- Fixed typo from 'when' to 'where'
- Removed unsupported file extension `html` from CSS Var Complete configuration