### PR TITLE
animate outline offset for buttons

### DIFF
--- a/src/extra/buttons.css
+++ b/src/extra/buttons.css
@@ -60,9 +60,10 @@
   }
 
   @media (--motionOK) {
-    transition: 
+    transition:
       border-color .5s var(--ease-3) 3s,
-      box-shadow 145ms var(--ease-4);
+      box-shadow 145ms var(--ease-4),
+      outline-offset 145ms var(--ease-4);
   }
 }
 


### PR DESCRIPTION
I noticed in your [intro video](https://www.youtube.com/watch?v=9VXR_qRgROE) (thanks, btw!) that you were puzzled as to why the `outline-offset` on your buttons wasn't animating. I think this fixes it?