### PR TITLE
 Package subpath './open-props.min.css' is not defined by "exports"

### DIFF
--- a/docsite/index.html
+++ b/docsite/index.html
@@ -1050,7 +1050,7 @@
                       plugins: [
                         postcssJitProps({
                           files: [
-                            require('open-props/open-props.min.css'),
+                            require('open-props/style'),
                           ]
                         }),
                       ]


### PR DESCRIPTION
Looks like the main docsite needs an update here as the latest package exports `open-props.min.css` as "style".