### PR TITLE
update autocomplete settings

### DIFF
--- a/docsite/index.html
+++ b/docsite/index.html
@@ -1141,7 +1141,7 @@
 
                   // add support for autocomplete in JS or JS like files
                   "cssvar.extensions": [
-                    "css", "jsx", "tsx"
+                    "css", "postcss", "jsx", "tsx"
                   ]
                 }
               </code></pre>


### PR DESCRIPTION
Currently that extension's setting works on language ID's and not file extensions. If the consumer project is using postcss, it must be specified in the setting to enable autocompletition on this language/files

Ref. https://github.com/willofindie/vscode-cssvar/issues/99