### PR TITLE
Fix redundant selectors in normalize

### DIFF
--- a/src/extra/buttons.css
+++ b/src/extra/buttons.css
@@ -1,7 +1,7 @@
 @import "../props.media.css";
 @import "../props.gray-hsl.css";
 
-:where(button,button[type],input[type="button"],input[type="submit"],input[type="reset"]),
+:where(button,input:is([type="button"],[type="submit"],[type="reset"])),
 :where(input[type="file"])::-webkit-file-upload-button,
 :where(input[type="file"])::file-selector-button {
   --_accent: initial /* your color */;
@@ -68,7 +68,7 @@
   }
 }
 
-:where(button,button[type],input[type="button"],input[type="submit"],input[type="reset"]) {
+:where(button,input:is([type="button"],[type="submit"],[type="reset"])) {
   /* disabled */
   &[disabled] {
     --_bg: none;

--- a/src/extra/buttons.dark.css
+++ b/src/extra/buttons.dark.css
@@ -1,7 +1,7 @@
 @import "../props.media.css";
 @import "../props.gray-hsl.css";
 
-:where(button,button[type],input[type="button"],input[type="submit"],input[type="reset"]),
+:where(button,input:is([type="button"],[type="submit"],[type="reset"])),
 :where(input[type="file"])::-webkit-file-upload-button,
 :where(input[type="file"])::file-selector-button {
   --_accent: initial /* your color */;
@@ -53,7 +53,7 @@
   }
 }
 
-:where(button,button[type],input[type="button"],input[type="submit"],input[type="reset"]) {
+:where(button,input:is([type="button"],[type="submit"],[type="reset"])) {
   /* disabled */
   &[disabled] {
     --_bg: none;

--- a/src/extra/buttons.light.css
+++ b/src/extra/buttons.light.css
@@ -1,7 +1,7 @@
 @import "../props.media.css";
 @import "../props.gray-hsl.css";
 
-:where(button,button[type],input[type="button"],input[type="submit"],input[type="reset"]),
+:where(button,input:is([type="button"],[type="submit"],[type="reset"])),
 :where(input[type="file"])::-webkit-file-upload-button,
 :where(input[type="file"])::file-selector-button {
   --_accent: initial /* your color */;
@@ -55,7 +55,7 @@
   }
 }
 
-:where(button,button[type],input[type="button"],input[type="submit"],input[type="reset"]) {
+:where(button,input:is([type="button"],[type="submit"],[type="reset"])) {
   /* disabled */
   &[disabled] {
     --_bg: none;

--- a/src/extra/normalize.css
+++ b/src/extra/normalize.css
@@ -3,7 +3,7 @@
 @import "normalize.src.css";
 
 @media (--OSdark) {
-  :where(textarea, select, input:not(button,button[type],input[type="button"],input[type="submit"],input[type="reset"])) {
+  :where(textarea, select, input:not([type="button"],[type="submit"],[type="reset"])) {
     background-color: hsl(210 11% 10%);
   }
 

--- a/src/extra/normalize.dark.css
+++ b/src/extra/normalize.dark.css
@@ -2,7 +2,7 @@
 @import "brand.css";
 @import "normalize.src.css";
 
-:where(textarea, select, input:not(button,button[type],input[type="button"],input[type="submit"],input[type="reset"])) {
+:where(textarea, select, input:not([type="button"],[type="submit"],[type="reset"])) {
   background-color: var(--gray-10);
 }
 

--- a/src/extra/normalize.src.css
+++ b/src/extra/normalize.src.css
@@ -145,10 +145,8 @@
   inline-size: var(--size-3);
 }
 
-:where(svg) {
-  &:where(:not([width])) {
-    inline-size: var(--size-10);
-  }
+:where(svg:not([width])) {
+  inline-size: var(--size-10);
 }
 
 :where(code, kbd, samp, pre) { font-family: var(--font-mono) }

--- a/src/extra/normalize.src.css
+++ b/src/extra/normalize.src.css
@@ -133,7 +133,7 @@
   padding-block: .75ch;
 }
 
-:where(textarea, select, input:not(button,button[type],input[type="button"],input[type="submit"],input[type="reset"])) {
+:where(textarea, select, input:not([type="button"],[type="submit"],[type="reset"])) {
   background-color: var(--surface-2);
   border-radius: var(--radius-2);
 }

--- a/src/extra/theme.dark.css
+++ b/src/extra/theme.dark.css
@@ -29,7 +29,7 @@
     }
   }
 
-  & :where(button,button[type],input[type="button"],input[type="submit"],input[type="reset"])[disabled] {
+  & :where(button,input:is([type="button"],[type="submit"],[type="reset"]))[disabled] {
     --_text: var(--gray-5);
   }
 

--- a/src/extra/theme.dark.css
+++ b/src/extra/theme.dark.css
@@ -33,7 +33,7 @@
     --_text: var(--gray-5);
   }
 
-  & :where(textarea, select, input:not(button,button[type],input[type="button"],input[type="submit"],input[type="reset"])) {
+  & :where(textarea, select, input:not([type="button"],[type="submit"],[type="reset"])) {
     background-color: hsl(210deg 11% 10%);
   }
 

--- a/src/extra/theme.dark.switch.css
+++ b/src/extra/theme.dark.switch.css
@@ -41,7 +41,7 @@
     --_text: var(--gray-5);
   }
 
-  & :where(textarea, select, input:not(button,button[type],input[type="button"],input[type="submit"],input[type="reset"])) {
+  & :where(textarea, select, input:not([type="button"],[type="submit"],[type="reset"])) {
     background-color: hsl(210deg 11% 10%);
   }
 

--- a/src/extra/theme.dark.switch.css
+++ b/src/extra/theme.dark.switch.css
@@ -37,7 +37,7 @@
     }
   }
 
-  & :where(button,button[type],input[type="button"],input[type="submit"],input[type="reset"])[disabled] {
+  & :where(button,input:is([type="button"],[type="submit"],[type="reset"]))[disabled] {
     --_text: var(--gray-5);
   }
 

--- a/src/extra/theme.light.css
+++ b/src/extra/theme.light.css
@@ -38,7 +38,7 @@
     }
   }
 
-  & :where(button,button[type],input[type="button"],input[type="submit"],input[type="reset"])[disabled] {
+  & :where(button,input:is([type="button"],[type="submit"],[type="reset"]))[disabled] {
     --_text: var(--gray-6);
   }
 

--- a/src/extra/theme.light.css
+++ b/src/extra/theme.light.css
@@ -42,7 +42,7 @@
     --_text: var(--gray-6);
   }
 
-  & :where(textarea, select, input:not(button,button[type],input[type="button"],input[type="submit"],input[type="reset"])) {
+  & :where(textarea, select, input:not([type="button"],[type="submit"],[type="reset"])) {
     background-color: var(--surface-2);
   }
 }

--- a/src/extra/theme.light.switch.css
+++ b/src/extra/theme.light.switch.css
@@ -48,7 +48,7 @@
     --_text: var(--gray-6);
   }
 
-  & :where(textarea, select, input:not(button,button[type],input[type="button"],input[type="submit"],input[type="reset"])) {
+  & :where(textarea, select, input:not([type="button"],[type="submit"],[type="reset"])) {
     background-color: var(--surface-2);
   }
 }

--- a/src/extra/theme.light.switch.css
+++ b/src/extra/theme.light.switch.css
@@ -44,7 +44,7 @@
     }
   }
 
-  & :where(button,button[type],input[type="button"],input[type="submit"],input[type="reset"])[disabled] {
+  & :where(button,input:is([type="button"],[type="submit"],[type="reset"]))[disabled] {
     --_text: var(--gray-6);
   }
 


### PR DESCRIPTION
Preparing a fork/variant of the "extra" styles and found some redundant selectors.

- Redundant element selectors in `input:not()` (`input` cannot also be `button`)
- Redundant `[type]` in `:where(button,button[type])` - has no effect since both selectors have 0 specificity
- Redundant nesting in `svg:not([width])`