### PR TITLE
docsite-op-logo-svg-fix

### DIFF
--- a/docsite/index.html
+++ b/docsite/index.html
@@ -51,7 +51,7 @@
     <nav>
       <a href="/">
         <svg class="op-icon" viewBox="0 0 200 200">
-          <line class="op-icon-p" x1="66" x2="66" y1="100" y2="175" stroke-width="25"/>
+          <line class="op-icon-p" x1="65" x2="65" y1="100" y2="175" stroke-width="25"/>
           <circle class="op-icon-p" cx="100" cy="100" r="35" fill="transparent" stroke-width="25"/>
           <circle class="op-icon-o" cx="100" cy="100" r="85" fill="transparent" stroke-width="25"/>
         </svg>


### PR DESCRIPTION
Hi, @argyleink

Once discovered i could not unsee it :sweat_smile:
Just a tiny tweak to align the "stem" with the inner circle.

Before:
![op-logo-svg-before](https://user-images.githubusercontent.com/1868037/228886098-6c3a94bc-cfa7-42ed-953a-18ea28ba7ceb.png)

After:
![op-logo-svg-after](https://user-images.githubusercontent.com/1868037/228886140-269db570-1544-4d35-86d5-48096670dd27.png)
