### PR TITLE
Fix accessibility issues on theme toggle button

### DIFF
--- a/docsite/index.html
+++ b/docsite/index.html
@@ -65,7 +65,7 @@
         Try in browser 
         <small class="green-badge">RAD</small>
       </a>
-      <button class="theme-toggle" id="theme-toggle" title="Toggles light & dark" aria-live="auto">
+      <button class="theme-toggle" id="theme-toggle" title="Toggles light & dark" aria-label="auto" aria-live="polite">
         <svg aria-hidden="true" width="24" height="24" viewBox="0 0 24 24">
           <!-- https://feathericons.com/?query=sun -->
           <mask id="moon">

--- a/docsite/public/theme-toggle.js
+++ b/docsite/public/theme-toggle.js
@@ -15,7 +15,7 @@ const setPreference = () => {
 
 const reflectPreference = () => {
   document.firstElementChild.setAttribute('data-theme', theme.value)
-  document.querySelector('#theme-toggle')?.setAttribute('aria-live', theme.value)
+  document.querySelector('#theme-toggle')?.setAttribute('aria-label', theme.value)
 }
 
 const theme = {


### PR DESCRIPTION
I fixed the attributes on the theme toggle button so that screen readers can recognize the current state of the light and dark theme.