### PR TITLE
Text cursor on text inputs

### DIFF
--- a/src/extra/normalize.src.css
+++ b/src/extra/normalize.src.css
@@ -76,8 +76,11 @@
   }
 }
 
-:where(a[href], area, button, input, label[for], select, summary, textarea, [tabindex]:not([tabindex*="-"])) {
+:where(a[href], area, button, input:not([type="text"], [type="email"], [type="number"], [type="password"], [type=""], [type="tel"], [type="url"]), label[for], select, summary, [tabindex]:not([tabindex*="-"])) {
   cursor: pointer;
+}
+
+:where(a[href], area, button, input, label[for], select, summary, textarea, [tabindex]:not([tabindex*="-"])) {
   touch-action: manipulation;
   -webkit-tap-highlight-color: transparent;
 }


### PR DESCRIPTION
Fixes #366

Not sure if you'd need to keep the `touch-action` and `-webkit-tap-highlight-color` on these excluded inputs. If so, that part should perhaps be extracted to a new block. Let me know if you'd prefer that