### PR TITLE
fix #375

### DIFF
--- a/docsite/js/animations.js
+++ b/docsite/js/animations.js
@@ -1,9 +1,9 @@
-import {toggleIcons} from './easing.js'
+import {showPlayIcon} from './easing.js'
 
 const cleanup = e => {
   setTimeout(()=> {
     e.target.style = ''
-    toggleIcons(e.target.querySelector('button'))
+    showPlayIcon(e.target.querySelector('button'))
   }, 500)
 }
 

--- a/docsite/js/easing.js
+++ b/docsite/js/easing.js
@@ -18,6 +18,18 @@ export const toggleIcons = button => {
     })
 }
 
+export const showPlayIcon = button => {
+  button
+    .querySelectorAll('use')
+    .forEach(icon => {
+      if (icon.getAttribute('href') === '#play-icon') {
+        icon.classList.remove('hidden')
+      } else {
+        icon.classList.add('hidden');
+      }
+    })
+}
+
 // play buttons
 document
   .querySelectorAll('.play-button')


### PR DESCRIPTION
When cleaning up after an animation has finished, instead of toggling which button to show, simply always show the play button.