### PR TITLE
fix breaking centered text-alignment for td, th

### DIFF
--- a/src/extra/normalize.src.css
+++ b/src/extra/normalize.src.css
@@ -346,6 +346,11 @@
   padding: var(--size-2);
 }
 
+td:where([align="center"]),
+th:where([align="center"]) {
+	text-align: center;
+}
+
 :where(thead) {
   border-collapse: collapse;
 }

--- a/src/extra/normalize.src.css
+++ b/src/extra/normalize.src.css
@@ -346,8 +346,7 @@
   padding: var(--size-2);
 }
 
-td:where([align="center"]),
-th:where([align="center"]) {
+:where(:is(td,th):not([align])) {
 	text-align: center;
 }
 


### PR DESCRIPTION
I noticed that :where(td,th) has text-align: left set, which messes things up when td or th has align="center" in their html tag. 

I fixed this issue, but I think it would be better to remove the alignment from :where(td,th) altogether, because it might also cause problems for right-to-left users.