### PR TITLE
(feat) Better support for row colors in tables

### DIFF
--- a/src/extra/normalize.src.css
+++ b/src/extra/normalize.src.css
@@ -296,7 +296,7 @@
 :where(table) {
   width: fit-content;
   border: 1px solid var(--surface-2);
-  background: var(--surface-2);
+  background: var(--surface-1);
   border-radius: var(--radius-3);
 
   --nice-inner-radius: calc(var(--radius-3) - 2px);
@@ -336,7 +336,6 @@
 }
 
 :where(td) {
-  background: var(--surface-1);
   max-inline-size: var(--size-content-2);
   text-wrap: pretty;
 }
@@ -348,6 +347,11 @@
 
 :where(thead) {
   border-collapse: collapse;
+  background: var(--surface-2);
+}
+
+:where(tfoot) {
+  background: var(--surface-2);
 }
 
 :where(table tr:hover td),


### PR DESCRIPTION
setting a color on the `td` prevents easy zebra striping. this commit moves the color to the table and the headerfoorter so it becomes easier to override the `tr` background color
