### PR TITLE
fix typo

### DIFF
--- a/src/props.supports.css
+++ b/src/props.supports.css
@@ -3,7 +3,7 @@
 @custom-media --firefoxMacONLY  (-moz-osx-font-smoothing: inherit);
 @custom-media --chromeONLY      (-webkit-app-region: inherit) and (not (container-type: none));
 @custom-media --chromiumONLY    (-webkit-app-region: inherit) and (container-type: none);
-@custom-media --webkitONLY      (alt: inherit) and (not (-apple-pay-button-style: inherit))
+@custom-media --webkitONLY      (alt: inherit) and (not (-apple-pay-button-style: inherit));
 
 :where(html) {
   --isLTR: 1;


### PR DESCRIPTION
Without the `;` the selectors and rules after the last custom media technically become part of the at rule prelude.