### PR TITLE
Logical Animation Directions

### DIFF
--- a/build/props.js
+++ b/build/props.js
@@ -145,6 +145,7 @@ buildPropsStylesheet({
 // gen index.css
 const entry = fs.createWriteStream(`../src/${pfx}index.css`)
 entry.write(`@import 'props.media.css';
+@import 'props.supports.css';
 `)
 Object.keys(mainbundle).forEach(filename => {
   entry.write(`@import '${filename}';\n`)

--- a/build/to-stylesheet.js
+++ b/build/to-stylesheet.js
@@ -9,6 +9,10 @@ export const buildPropsStylesheet = ({filename,props}, {selector,prefix}) => {
     file.write(`@import 'props.media.css';\n\n`)
   }
 
+  if(filename.includes('animations')) {
+    file.write(`@import 'props.supports.css';\n\n`)
+  }
+
   if (filename.includes('shadows')) {
     let dark_propsMeta = ``
     let dark_props = Object.entries(props)
@@ -40,7 +44,9 @@ ${dark_propsMeta}
 
     if (prop.includes('animation')) {
       let keyframes = props[`${prop}-@`]
-      appendedMeta += keyframes
+      if(keyframes != undefined) {
+        appendedMeta += keyframes
+      }
     }
 
     if (prefix && prefix !== "''") {

--- a/build/to-stylesheet.js
+++ b/build/to-stylesheet.js
@@ -5,11 +5,10 @@ export const buildPropsStylesheet = ({filename,props}, {selector,prefix}) => {
 
   let appendedMeta = ''
 
-  if (filename.includes('shadows') || filename.includes('animations')) {
+  if (filename.includes('shadows')) {
     file.write(`@import 'props.media.css';\n\n`)
-  }
-
-  if(filename.includes('animations')) {
+  } else if(filename.includes('animations')) {
+    file.write(`@import 'props.media.css';\n`)
     file.write(`@import 'props.supports.css';\n\n`)
   }
 

--- a/docsite/index.css
+++ b/docsite/index.css
@@ -1386,10 +1386,10 @@ input[type="range"] {
 }
 
 .shake-fade-combo {
-  --animation-slide-left-fade-in-shake-y: 
+  --animation-slide-start-fade-in-shake-y: 
     var(--animation-shake-y),
     var(--animation-fade-in),
-    var(--animation-slide-in-left);
+    var(--animation-slide-in-start);
 }
 
 .push-out-combo {

--- a/docsite/index.html
+++ b/docsite/index.html
@@ -2443,8 +2443,8 @@
               --animation-fade-{in,out}-bloom
               --animation-shake-{x,y}
 
-              --animation-slide-out-{up,down,left,right}
-              --animation-slide-in-{up,down,left,right}
+              --animation-slide-out-{up,down,start,end}
+              --animation-slide-in-{up,down,start,end}
 
               --animation-spin
               --animation-ping
@@ -2463,7 +2463,7 @@
                 to { opacity: 1 }
               }
 
-              @keyframes op-slide-out-right {
+              @keyframes op-slide-out-end {
                 to { transform: translateX(100%) }
               }
 
@@ -2584,8 +2584,8 @@
             </button>
           </div>
 
-          <div class="animation-demo-target" data-animation="slide-out-right">
-            <h6>Slide Out Right</h6>
+          <div class="animation-demo-target" data-animation="slide-out-end">
+            <h6>Slide Out End</h6>
             <button class="play-button">
               <svg viewBox="0 0 20 20">
                 <use href="#play-icon"/>
@@ -2594,8 +2594,8 @@
             </button>
           </div>
 
-          <div class="animation-demo-target" data-animation="slide-out-left">
-            <h6>Slide Out Left</h6>
+          <div class="animation-demo-target" data-animation="slide-out-start">
+            <h6>Slide Out Start</h6>
             <button class="play-button">
               <svg viewBox="0 0 20 20">
                 <use href="#play-icon"/>
@@ -2624,8 +2624,8 @@
             </button>
           </div>
 
-          <div class="animation-demo-target" data-animation="slide-in-right">
-            <h6>Slide In Right</h6>
+          <div class="animation-demo-target" data-animation="slide-in-end">
+            <h6>Slide In End</h6>
             <button class="play-button">
               <svg viewBox="0 0 20 20">
                 <use href="#play-icon"/>
@@ -2634,8 +2634,8 @@
             </button>
           </div>
 
-          <div class="animation-demo-target" data-animation="slide-in-left">
-            <h6>Slide In Left</h6>
+          <div class="animation-demo-target" data-animation="slide-in-start">
+            <h6>Slide In Start</h6>
             <button class="play-button">
               <svg viewBox="0 0 20 20">
                 <use href="#play-icon"/>
@@ -2754,7 +2754,7 @@
 
           <div class="animation-pair">
             <!-- data-starting-styles="opacity:0" -->
-            <div class="animation-demo-target shake-fade-combo" data-animation="slide-left-fade-in-shake-y">
+            <div class="animation-demo-target shake-fade-combo" data-animation="slide-start-fade-in-shake-y">
               <h6>Shake In</h6>
               <button class="play-button">
                 <svg viewBox="0 0 20 20">
@@ -2769,7 +2769,7 @@
                   animation: 
                     var(--animation-shake-y),
                     var(--animation-fade-in),
-                    var(--animation-slide-in-left);
+                    var(--animation-slide-in-start);
                 }
               </code></pre>
             </div>

--- a/src/index.css
+++ b/src/index.css
@@ -1,4 +1,5 @@
 @import 'props.media.css';
+@import 'props.supports.css';
 @import 'props.fonts.css';
 @import 'props.sizes.css';
 @import 'props.easing.css';

--- a/src/props.animations.css
+++ b/src/props.animations.css
@@ -1,5 +1,4 @@
 @import 'props.media.css';
-
 @import 'props.supports.css';
 
 :where(html) {

--- a/src/props.animations.css
+++ b/src/props.animations.css
@@ -1,5 +1,7 @@
 @import 'props.media.css';
 
+@import 'props.supports.css';
+
 :where(html) {
   --animation-fade-in: fade-in .5s var(--ease-3);
   --animation-fade-in-bloom: fade-in-bloom 2s var(--ease-3);
@@ -9,12 +11,16 @@
   --animation-scale-down: scale-down .5s var(--ease-3);
   --animation-slide-out-up: slide-out-up .5s var(--ease-3);
   --animation-slide-out-down: slide-out-down .5s var(--ease-3);
-  --animation-slide-out-right: slide-out-right .5s var(--ease-3);
-  --animation-slide-out-left: slide-out-left .5s var(--ease-3);
+  --animation-slide-out-end: slide-out-end .5s var(--ease-3);
+  --animation-slide-out-right: var(--animation-slide-out-end);
+  --animation-slide-out-start: slide-out-start .5s var(--ease-3);
+  --animation-slide-out-left: var(--animation-slide-out-start);
   --animation-slide-in-up: slide-in-up .5s var(--ease-3);
   --animation-slide-in-down: slide-in-down .5s var(--ease-3);
-  --animation-slide-in-right: slide-in-right .5s var(--ease-3);
-  --animation-slide-in-left: slide-in-left .5s var(--ease-3);
+  --animation-slide-in-end: slide-in-end .5s var(--ease-3);
+  --animation-slide-in-right: var(--animation-slide-in-end);
+  --animation-slide-in-start: slide-in-start .5s var(--ease-3);
+  --animation-slide-in-left: var(--animation-slide-in-start);
   --animation-shake-x: shake-x .75s var(--ease-out-5);
   --animation-shake-y: shake-y .75s var(--ease-out-5);
   --animation-spin: spin 2s linear infinite;
@@ -53,11 +59,11 @@
 @keyframes slide-out-down {
   to { transform: translateY(100%) }
 }
-@keyframes slide-out-right {
-  to { transform: translateX(100%) }
+@keyframes slide-out-end {
+  to { transform: translateX(calc(100% * var(--isLTR))) }
 }
-@keyframes slide-out-left {
-  to { transform: translateX(-100%) }
+@keyframes slide-out-start {
+  to { transform: translateX(calc(-100% * var(--isLTR))) }
 }
 @keyframes slide-in-up {
   from { transform: translateY(100%) }
@@ -65,11 +71,11 @@
 @keyframes slide-in-down {
   from { transform: translateY(-100%) }
 }
-@keyframes slide-in-right {
-  from { transform: translateX(-100%) }
+@keyframes slide-in-end {
+  from { transform: translateX(calc(-100% * var(--isLTR))) }
 }
-@keyframes slide-in-left {
-  from { transform: translateX(100%) }
+@keyframes slide-in-start {
+  from { transform: translateX(calc(100% * var(--isLTR))) }
 }
 @keyframes shake-x {
   0%, 100% { transform: translateX(0%) }

--- a/src/props.animations.js
+++ b/src/props.animations.js
@@ -55,16 +55,18 @@ export default {
 @keyframes slide-out-down {
   to { transform: translateY(100%) }
 }`,
-  "--animation-slide-out-right": "slide-out-right .5s var(--ease-3)", 
-  "--animation-slide-out-right-@": `
-@keyframes slide-out-right {
-  to { transform: translateX(100%) }
+"--animation-slide-out-end": "slide-out-end .5s var(--ease-3)", 
+"--animation-slide-out-end-@": `
+@keyframes slide-out-end {
+  to { transform: translateX(calc(100% * var(--isLTR))) }
 }`,
-  "--animation-slide-out-left": "slide-out-left .5s var(--ease-3)", 
-  "--animation-slide-out-left-@": `
-@keyframes slide-out-left {
-  to { transform: translateX(-100%) }
+  "--animation-slide-out-right": "var(--animation-slide-out-end)",
+  "--animation-slide-out-start": "slide-out-start .5s var(--ease-3)", 
+  "--animation-slide-out-start-@": `
+@keyframes slide-out-start {
+  to { transform: translateX(calc(-100% * var(--isLTR))) }
 }`,
+  "--animation-slide-out-left": "var(--animation-slide-out-start)",  
   "--animation-slide-in-up": "slide-in-up .5s var(--ease-3)", 
   "--animation-slide-in-up-@": `
 @keyframes slide-in-up {
@@ -75,16 +77,18 @@ export default {
 @keyframes slide-in-down {
   from { transform: translateY(-100%) }
 }`,
-  "--animation-slide-in-right": "slide-in-right .5s var(--ease-3)", 
-  "--animation-slide-in-right-@": `
-@keyframes slide-in-right {
-  from { transform: translateX(-100%) }
+  "--animation-slide-in-end": "slide-in-end .5s var(--ease-3)", 
+  "--animation-slide-in-end-@": `
+@keyframes slide-in-end {
+  from { transform: translateX(calc(-100% * var(--isLTR))) }
 }`,
-  "--animation-slide-in-left": "slide-in-left .5s var(--ease-3)", 
-  "--animation-slide-in-left-@": `
-@keyframes slide-in-left {
-  from { transform: translateX(100%) }
+  "--animation-slide-in-right": "var(--animation-slide-in-end)",
+  "--animation-slide-in-start": "slide-in-start .5s var(--ease-3)", 
+  "--animation-slide-in-start-@": `
+@keyframes slide-in-start {
+  from { transform: translateX(calc(100% * var(--isLTR))) }
 }`,
+  "--animation-slide-in-left": "var(--animation-slide-in-start)",
   "--animation-shake-x": "shake-x .75s var(--ease-out-5)", 
   "--animation-shake-x-@": `
 @keyframes shake-x {

--- a/src/props.supports.css
+++ b/src/props.supports.css
@@ -8,8 +8,15 @@
 :where(html) {
   --isLTR: 1;
   --isRTL: -1;
-  
+
   &:dir(rtl) {
+      /* PostCSS compiles this to [dir="rtl"] :where(html) for older browsers, which doesn't work */
+    --isLTR: -1;
+    --isRTL: 1;
+  }
+
+  &[dir="rtl"] {
+    /* Force the dir attribute selector to attach to :where(html) */
     --isLTR: -1;
     --isRTL: 1;
   }

--- a/test/basic.test.cjs
+++ b/test/basic.test.cjs
@@ -4,7 +4,7 @@ const OpenProps = require('../dist/open-props.cjs')
 const OPtokens = require('../open-props.tokens.json')
 
 test('Should have an all included import', t => {
-  t.is(Object.keys(OpenProps).length, 1612)
+  t.is(Object.keys(OpenProps).length, 1620)
 })
 
 test('Import should have animations', async t => {


### PR DESCRIPTION
As per: https://github.com/argyleink/open-props/issues/390

- Slide in/out animations have been updated to use `{start, end}` instead of `{left, right}`
- Animations using logical directions autodetect HTML `dir` attribute
- Aliases to old prop names have been created
- Bugfix for `--isLTR` and `--isRTL` props
- Minor build script changes to add in necessary stylesheets and allow 1:n mapping of named animations/keyframes to animation props (vs 1:1 currently)
- Updated docs with new names

Unsure if this is overkill! Similarly, this seems like a minor version bump with the aliases to the old prop names, but this might break apps for people who've created RTL pages and using the 'opposite' prop to compensate, so I didn't bump the version.