### PR TITLE
[Draft]: uno preset

### DIFF
--- a/package.json
+++ b/package.json
@@ -175,6 +175,7 @@
     "./postcss/theme-dark": "./src/extra/theme-dark.css",
     "./postcss/theme-light": "./src/extra/theme-light.css",
     "./utilities": "./src/extra/utilities.css",
+    "./preset-unocss": "./src/presets/unocss/index.js",
     "./*": "./*"
   },
   "browserslist": [
@@ -189,6 +190,7 @@
     "gen:shadowdom": "cd build && node props \"\" false \":host\" \"shadow\"",
     "gen:prefixed": "cd build && node props.js \"op\" true",
     "gen:types": "tsc -p tsconfig.json",
+    "gen:unocss": "tsc -p src/presets/unocss/tsconfig.json",
     "lib:all": "postcss src/index.css -o open-props.min.css",
     "lib:normalize": "postcss src/extra/normalize.css -o normalize.min.css && node ./build/extras.js",
     "lib:normalize:light": "postcss src/extra/normalize.light.css -o normalize.light.min.css",

--- a/package.json
+++ b/package.json
@@ -190,7 +190,6 @@
     "gen:shadowdom": "cd build && node props \"\" false \":host\" \"shadow\"",
     "gen:prefixed": "cd build && node props.js \"op\" true",
     "gen:types": "tsc -p tsconfig.json",
-    "gen:unocss": "tsc -p src/presets/unocss/tsconfig.json",
     "lib:all": "postcss src/index.css -o open-props.min.css",
     "lib:normalize": "postcss src/extra/normalize.css -o normalize.min.css && node ./build/extras.js",
     "lib:normalize:light": "postcss src/extra/normalize.light.css -o normalize.light.min.css",

--- a/src/presets/unocss/index.js
+++ b/src/presets/unocss/index.js
@@ -6,8 +6,8 @@ export const openPropsPreset = {
   rules: [
     [
       /^op-color-(.*)$/,
-      ([, c], { theme }) => {
-        const normalizedVariable = `--${c}`;
+      ([, token], { theme }) => {
+        const normalizedVariable = `--${token}`;
         if (theme["colors"][normalizedVariable]) {
           return { color: theme["colors"][normalizedVariable] };
         }
@@ -15,8 +15,8 @@ export const openPropsPreset = {
     ],
     [
       /^op-font-(.*)$/,
-      ([, c], { theme }) => {
-        const normalizedVariable = `--font-${c}`;
+      ([, token], { theme }) => {
+        const normalizedVariable = `--font-${token}`;
         if (theme["fontFamily"][normalizedVariable]) {
           return { "font-family": theme["fontFamily"][normalizedVariable] };
         }

--- a/src/presets/unocss/index.js
+++ b/src/presets/unocss/index.js
@@ -1,0 +1,30 @@
+import Colors from "../../../src/props.colors.js";
+import Fonts from "../../../src/props.fonts.js";
+
+export const openPropsPreset = {
+  name: "unocss-preset-open-props",
+  rules: [
+    [
+      /^op-color-(.*)$/,
+      ([, c], { theme }) => {
+        const normalizedVariable = `--${c}`;
+        if (theme["colors"][normalizedVariable]) {
+          return { color: theme["colors"][normalizedVariable] };
+        }
+      },
+    ],
+    [
+      /^op-font-(.*)$/,
+      ([, c], { theme }) => {
+        const normalizedVariable = `--font-${c}`;
+        if (theme["fontFamily"][normalizedVariable]) {
+          return { "font-family": theme["fontFamily"][normalizedVariable] };
+        }
+      },
+    ],
+  ],
+  theme: {
+    colors: Colors,
+    fontFamily: Fonts,
+  },
+};


### PR DESCRIPTION
This is a work-in-progress PR, which fixes https://github.com/argyleink/open-props/issues/406

I learned a lot about how to translate CSS variables into something that could be effectively applied as a style by a framework like https://unocss.dev/

I need to take a look at what other themes and rules it would make sense to define as part of this preset.

As it stands, you can apply styles that use the font and color variables via class names like `op-font-sans` or `op-color-choco-4`.