### PR TITLE
Style dictionary tokens

### DIFF
--- a/build/props.js
+++ b/build/props.js
@@ -22,6 +22,7 @@ import {buildPropsStylesheet} from './to-stylesheet.js'
 import {toTokens} from './to-tokens.js'
 import {toObject} from './to-object.js'
 import {toFigmaTokens} from './to-figmatokens.js'
+import {toStyleDictionary} from './to-style-dictionary.js'
 
 const [,,prefix='',useWhere,customSubject='',filePrefix=''] = process.argv
 
@@ -76,6 +77,11 @@ const jsonbundle = Object.entries({
 const designtokens = toTokens(jsonbundle)
 const JSONtokens = fs.createWriteStream('../open-props.tokens.json')
 JSONtokens.end(JSON.stringify(Object.fromEntries(designtokens), null, 2))
+
+// gen style-dictionary tokens
+const styledictionary = toStyleDictionary(designtokens)
+const JSONStyleDictionaryTokens = fs.createWriteStream('../open-props.style-dictionary-tokens.json')
+JSONStyleDictionaryTokens.end(JSON.stringify(styledictionary, null, 2))
 
 // gen figma tokens
 const figmatokens = toFigmaTokens(jsonbundle)

--- a/build/props.js
+++ b/build/props.js
@@ -79,9 +79,9 @@ const JSONtokens = fs.createWriteStream('../open-props.tokens.json')
 JSONtokens.end(JSON.stringify(Object.fromEntries(designtokens), null, 2))
 
 // gen style-dictionary tokens
-const styledictionary = toStyleDictionary(designtokens)
-const JSONStyleDictionaryTokens = fs.createWriteStream('../open-props.style-dictionary-tokens.json')
-JSONStyleDictionaryTokens.end(JSON.stringify(styledictionary, null, 2))
+const styledictionarytokens = toStyleDictionary(jsonbundle)
+const StyleDictionaryTokens = fs.createWriteStream('../open-props.style-dictionary-tokens.json')
+StyleDictionaryTokens.end(JSON.stringify(styledictionarytokens, null, 2))
 
 // gen figma tokens
 const figmatokens = toFigmaTokens(jsonbundle)

--- a/build/to-style-dictionary.js
+++ b/build/to-style-dictionary.js
@@ -8,9 +8,9 @@ const dictionaryMap = {
   "border-size":         "size",
   "radius-conditional":  "conditional",
   "radius-blob":         "blob"
-};
+}
 
-const mapToDictionaryKey = (value) => dictionaryMap[value] || value;
+const mapToDictionaryKey = (value) => dictionaryMap[value] || value
 
 const getTypeKey = (metaType) => {
   if (metaType === "size" || metaType === "border-radius") {
@@ -19,9 +19,9 @@ const getTypeKey = (metaType) => {
     return "border"
   }
   return metaType
-};
+}
 
-const countOccurrences = (str, letter) => (str.match(new RegExp(letter, 'g')) || []).length;
+const countOccurrences = (str, letter) => (str.match(new RegExp(letter, 'g')) || []).length
 
 const cssVarUsageRegex = /var\(--([a-zA-Z0-9-]+)\)/g
 
@@ -36,21 +36,20 @@ const replaceLast = (str, pattern, replacement) => {
   return last !== -1
     ? `${str.slice(0, last)}${replacement}${str.slice(last + match.length)}`
     : str
-};
+}
 
 const cssVarToTokenReference = (input) => {
   if (input.toString().indexOf("var") !== -1) {
-
     return input.replace(cssVarUsageRegex, (match, variableName) => {
       if (countOccurrences(variableName, '-') > 1) {
-        const varParts = replaceLast(variableName, '-', '.');
-        return `{${varParts}.value}`;
+        const varParts = replaceLast(variableName, '-', '.')
+        return `{${varParts}.value}`
       }
-      return `{${variableName.replace("-", ".")}.value}`;
-    });
+      return `{${variableName.replace("-", ".")}.value}`
+    })
   }
-  return input;
-};
+  return input
+}
 
 const createTokenObject = ({
   baseObj,
@@ -60,43 +59,45 @@ const createTokenObject = ({
   index,
   token
 }) => {
-  const typeKey = getTypeKey(metaType);
-  const targetObj = baseObj[typeKey] = baseObj[typeKey] || {};
+  const typeKey   = getTypeKey(metaType)
+  const targetObj = baseObj[typeKey] = baseObj[typeKey] || {}
 
   if (typeKey === "size" || typeKey === "radius") {
     const shouldReplace = mainKey !== dictionarykey
-    handleKey(targetObj, dictionarykey, index, token, metaType, shouldReplace);
+    handleKey(targetObj, dictionarykey, index, token, metaType, shouldReplace)
   } else if (typeKey !== "other") {
-    handleKey(targetObj, dictionarykey, index, token, metaType, true);
+    handleKey(targetObj, dictionarykey, index, token, metaType, true)
   } else {
-    handleOtherTypes(targetObj, dictionarykey, index, token, metaType);
+    handleOtherTypes(targetObj, dictionarykey, index, token, metaType)
   }
 
-  return baseObj;
+  return baseObj
 }
 
 // Handle cases where meta.type != "other"
 function handleKey(targetObj, dictionarykey, index, token, metaType, shouldReplace) {
   if (shouldReplace) {
-    targetObj[dictionarykey] = targetObj[dictionarykey] || {};
-    targetObj[dictionarykey][index] = { value: token, type: metaType };
+    targetObj[dictionarykey]        = targetObj[dictionarykey] || {}
+    targetObj[dictionarykey][index] = { value: token, type: metaType }
   } else {
-    targetObj[index] = { value: token, type: metaType };
+    targetObj[index] = { value: token, type: metaType }
   }
 }
 
 // Handle cases where meta.type = "other"
 function handleOtherTypes(targetObj, dictionarykey, index, token, metaType) {
-  const keyParts = dictionarykey.split("-");
-  if (keyParts.length > 1) {
-    const groupName = keyParts[0];
-    targetObj[groupName] = targetObj[groupName] || {};
-    targetObj[groupName][index] = { value: token, type: metaType };
+  const keyParts = dictionarykey.split("-")
 
-    const rest = keyParts.slice(1);
-    const subKey = rest.join("-");
-    targetObj[groupName][subKey] = targetObj[groupName][subKey] || {};
-    targetObj[groupName][subKey][index] = { value: token, type: metaType };
+  if (keyParts.length > 1) {
+    const groupName             = keyParts[0]
+    targetObj[groupName]        = targetObj[groupName] || {}
+    targetObj[groupName][index] = { value: token, type: metaType }
+
+    const rest   = keyParts.slice(1)
+    const subKey = rest.join("-")
+
+    targetObj[groupName][subKey]        = targetObj[groupName][subKey] || {}
+    targetObj[groupName][subKey][index] = { value: token, type: metaType }
   }
 }
 
@@ -106,26 +107,27 @@ export const toStyleDictionary = props => {
     .map(hueName => hueName.toLowerCase())
 
   return props.reduce((styledictionarytokens, [key, token]) => {
-    const meta = {};
-    const isLength = key.includes('size') && !key.includes('border-size');
-    const isBorder = key.includes('border-size');
-    const isRadius = key.includes('radius');
-    const isShadow = key.includes('shadow');
-    const isColor = colors.some(color => key.includes(color));
+    const meta = {}
 
-    if (isLength) meta.type = 'size';
-    else if (isBorder) meta.type = 'border-width';
-    else if (isRadius) meta.type = 'border-radius';
-    else if (isShadow) meta.type = 'box-shadow';
-    else if (isColor) meta.type = 'color';
-    else meta.type = 'other';
+    const isLength = key.includes('size') && !key.includes('border-size')
+    const isBorder = key.includes('border-size')
+    const isRadius = key.includes('radius')
+    const isShadow = key.includes('shadow')
+    const isColor  = colors.some(color => key.includes(color))
 
-    const keyWithoutPrefix = key.replace('--', '');
-    const keyParts = keyWithoutPrefix.split('-');
-    const mainKey = keyParts.length > 1 ? keyParts.slice(0, -1).join('-') : keyParts[0];
-    const index = keyParts.length > 1 ? keyParts[keyParts.length - 1] : 0;
+    if      (isLength) meta.type = 'size'
+    else if (isBorder) meta.type = 'border-width'
+    else if (isRadius) meta.type = 'border-radius'
+    else if (isShadow) meta.type = 'box-shadow'
+    else if (isColor)  meta.type  = 'color'
+    else               meta.type = 'other'
 
-    const dictionarykey = mapToDictionaryKey(mainKey);
+    const keyWithoutPrefix = key.replace('--', '')
+    const keyParts         = keyWithoutPrefix.split('-')
+    const mainKey          = keyParts.length > 1 ? keyParts.slice(0, -1).join('-') : keyParts[0]
+    const index            = keyParts.length > 1 ? keyParts[keyParts.length - 1] : 0
+
+    const dictionarykey = mapToDictionaryKey(mainKey)
 
     return createTokenObject({
       baseObj: styledictionarytokens,
@@ -133,7 +135,7 @@ export const toStyleDictionary = props => {
       metaType: meta.type,
       dictionarykey,
       index,
-      token: cssVarToTokenReference(token),
-    });
-  }, {});
+      token: cssVarToTokenReference(token)
+    })
+  }, {})
 }

--- a/build/to-style-dictionary.js
+++ b/build/to-style-dictionary.js
@@ -21,6 +21,37 @@ const getTypeKey = (metaType) => {
   return metaType
 };
 
+const countOccurrences = (str, letter) => (str.match(new RegExp(letter, 'g')) || []).length;
+
+const cssVarUsageRegex = /var\(--([a-zA-Z0-9-]+)\)/g
+
+/* https://www.30secondsofcode.org/js/s/replace-last-occurrence/ */
+const replaceLast = (str, pattern, replacement) => {
+  const match =
+    typeof pattern === 'string'
+      ? pattern
+      : (str.match(new RegExp(pattern.source, 'g')) || []).slice(-1)[0]
+  if (!match) return str
+  const last = str.lastIndexOf(match)
+  return last !== -1
+    ? `${str.slice(0, last)}${replacement}${str.slice(last + match.length)}`
+    : str
+};
+
+const cssVarToTokenReference = (input) => {
+  if (input.toString().indexOf("var") !== -1) {
+
+    return input.replace(cssVarUsageRegex, (match, variableName) => {
+      if (countOccurrences(variableName, '-') > 1) {
+        const varParts = replaceLast(variableName, '-', '.');
+        return `{${varParts}.value}`;
+      }
+      return `{${variableName.replace("-", ".")}.value}`;
+    });
+  }
+  return input;
+};
+
 const createTokenObject = ({
   baseObj,
   mainKey,
@@ -102,7 +133,7 @@ export const toStyleDictionary = props => {
       metaType: meta.type,
       dictionarykey: dictionarykey,
       index: index,
-      token: token
+      token: cssVarToTokenReference(token)
     })
   })
 

--- a/build/to-style-dictionary.js
+++ b/build/to-style-dictionary.js
@@ -1,27 +1,110 @@
-export const toStyleDictionary = (designtokens) => {
-  const tokens = Object.fromEntries(designtokens);
+import * as Colors from '../src/props.colors.js'
 
-  const transformedJson = {};
+const dictionaryMap = {
+  "size-relative":       "relative",
+  "size-fluid":          "fluid",
+  "size-header":         "header",
+  "size-content":        "content",
+  "border-size":         "size",
+  "radius-conditional":  "conditional",
+  "radius-blob":         "blob"
+};
 
-  for (const item in tokens) {
-    const tokenInfo = tokens[item];
+const mapToDictionaryKey = (value) => dictionaryMap[value] || value;
 
-    const keyWithoutPrefix = item.replace('--', '');
-    const keyParts = keyWithoutPrefix.split('-');
-    const mainKey =
-      keyParts.length > 1 ? keyParts.slice(0, -1).join('-') : keyParts[0];
-    const index = keyParts.length > 1 ? keyParts[keyParts.length - 1] : 0;
+const getTypeKey = (metaType) => {
+  if (metaType === "size" || metaType === "border-radius") {
+    return metaType === "size" ? "size" : "radius"
+  } else if (metaType === "border-width") {
+    return "border"
+  }
+  return metaType
+};
 
-    const { $value, $type, ...meta } = tokenInfo;
-    const value = $value;
-    const type = $type;
+const createTokenObject = ({
+  baseObj,
+  mainKey,
+  metaType,
+  dictionarykey,
+  index,
+  token
+}) => {
+  // Determine if the main key should be handled separately
+  const shouldHandleMainKey = mainKey !== dictionarykey
+  // Determine the type key based on metaType
+  const typeKey = getTypeKey(metaType)
 
-    if (!transformedJson[mainKey]) {
-      transformedJson[mainKey] = {};
+  // Initialize the typeKey in the baseObj if it doesn't exist
+  baseObj[typeKey] = baseObj[typeKey] || {}
+  // Define the target object
+  const targetObj = baseObj[typeKey]
+
+  if(typeKey === "size" || typeKey === "radius") {
+    if(shouldHandleMainKey){
+      // Handle main key separately
+      targetObj[dictionarykey] = targetObj[dictionarykey] || {}
+      targetObj[dictionarykey][index] = {
+        value: token,
+        type: metaType
+      }
+    } else {
+      // Handle main key directly
+      targetObj[index] = {
+        value: token,
+        type: metaType
+      }
     }
-
-    transformedJson[mainKey][index] = { value, type, ...meta };
+  } else {
+    // Handle all other types
+    targetObj[dictionarykey] = targetObj[dictionarykey] || {}
+    targetObj[dictionarykey][index] = {
+      value: token,
+      type: metaType
+    }
   }
 
-  return transformedJson;
+  return baseObj
 };
+
+export const toStyleDictionary = props => {
+  const styledictionarytokens = {}
+
+  const colors = Object.keys(Colors)
+        .filter(exportName => exportName !== "default")
+        .map(hueName => hueName.toLowerCase())
+
+  props.forEach(([key, token]) => {
+    const meta = {}
+
+    const isLength = key.includes('size') && !key.includes('border-size')
+    const isBorder = key.includes('border-size')
+    const isRadius = key.includes('radius')
+    const isShadow = key.includes('shadow')
+    const isColor = colors.some(color => key.includes(color))
+
+    if      (isLength) meta.type = 'size'
+    else if (isBorder) meta.type = 'border-width'
+    else if (isRadius) meta.type = 'border-radius'
+    else if (isShadow) meta.type = 'box-shadow'
+    else if (isColor)  meta.type = 'color'
+    else               meta.type = 'other'
+
+    const keyWithoutPrefix = key.replace('--', '')
+    const keyParts = keyWithoutPrefix.split('-')
+    const mainKey = keyParts.length > 1 ? keyParts.slice(0, -1).join('-') : keyParts[0]
+    const index = keyParts.length > 1 ? keyParts[keyParts.length - 1] : 0
+
+    const dictionarykey = mapToDictionaryKey(mainKey)
+
+    createTokenObject({
+      baseObj: styledictionarytokens,
+      mainKey: mainKey,
+      metaType: meta.type,
+      dictionarykey: dictionarykey,
+      index: index,
+      token: token
+    })
+  })
+
+  return styledictionarytokens
+}

--- a/build/to-style-dictionary.js
+++ b/build/to-style-dictionary.js
@@ -1,0 +1,27 @@
+export const toStyleDictionary = (designtokens) => {
+  const tokens = Object.fromEntries(designtokens);
+
+  const transformedJson = {};
+
+  for (const item in tokens) {
+    const tokenInfo = tokens[item];
+
+    const keyWithoutPrefix = item.replace('--', '');
+    const keyParts = keyWithoutPrefix.split('-');
+    const mainKey =
+      keyParts.length > 1 ? keyParts.slice(0, -1).join('-') : keyParts[0];
+    const index = keyParts.length > 1 ? keyParts[keyParts.length - 1] : 0;
+
+    const { $value, $type, ...meta } = tokenInfo;
+    const value = $value;
+    const type = $type;
+
+    if (!transformedJson[mainKey]) {
+      transformedJson[mainKey] = {};
+    }
+
+    transformedJson[mainKey][index] = { value, type, ...meta };
+  }
+
+  return transformedJson;
+};

--- a/build/to-style-dictionary.js
+++ b/build/to-style-dictionary.js
@@ -101,44 +101,39 @@ function handleOtherTypes(targetObj, dictionarykey, index, token, metaType) {
 }
 
 export const toStyleDictionary = props => {
-  const styledictionarytokens = {}
-
   const colors = Object.keys(Colors)
-        .filter(exportName => exportName !== "default")
-        .map(hueName => hueName.toLowerCase())
+    .filter(exportName => exportName !== "default")
+    .map(hueName => hueName.toLowerCase())
 
-  props.forEach(([key, token]) => {
-    const meta = {}
+  return props.reduce((styledictionarytokens, [key, token]) => {
+    const meta = {};
+    const isLength = key.includes('size') && !key.includes('border-size');
+    const isBorder = key.includes('border-size');
+    const isRadius = key.includes('radius');
+    const isShadow = key.includes('shadow');
+    const isColor = colors.some(color => key.includes(color));
 
-    const isLength = key.includes('size') && !key.includes('border-size')
-    const isBorder = key.includes('border-size')
-    const isRadius = key.includes('radius')
-    const isShadow = key.includes('shadow')
-    const isColor = colors.some(color => key.includes(color))
+    if (isLength) meta.type = 'size';
+    else if (isBorder) meta.type = 'border-width';
+    else if (isRadius) meta.type = 'border-radius';
+    else if (isShadow) meta.type = 'box-shadow';
+    else if (isColor) meta.type = 'color';
+    else meta.type = 'other';
 
-    if      (isLength) meta.type = 'size'
-    else if (isBorder) meta.type = 'border-width'
-    else if (isRadius) meta.type = 'border-radius'
-    else if (isShadow) meta.type = 'box-shadow'
-    else if (isColor)  meta.type = 'color'
-    else               meta.type = 'other'
+    const keyWithoutPrefix = key.replace('--', '');
+    const keyParts = keyWithoutPrefix.split('-');
+    const mainKey = keyParts.length > 1 ? keyParts.slice(0, -1).join('-') : keyParts[0];
+    const index = keyParts.length > 1 ? keyParts[keyParts.length - 1] : 0;
 
-    const keyWithoutPrefix = key.replace('--', '')
-    const keyParts = keyWithoutPrefix.split('-')
-    const mainKey = keyParts.length > 1 ? keyParts.slice(0, -1).join('-') : keyParts[0]
-    const index = keyParts.length > 1 ? keyParts[keyParts.length - 1] : 0
+    const dictionarykey = mapToDictionaryKey(mainKey);
 
-    const dictionarykey = mapToDictionaryKey(mainKey)
-
-    createTokenObject({
+    return createTokenObject({
       baseObj: styledictionarytokens,
-      mainKey: mainKey,
+      mainKey,
       metaType: meta.type,
-      dictionarykey: dictionarykey,
-      index: index,
-      token: cssVarToTokenReference(token)
-    })
-  })
-
-  return styledictionarytokens
+      dictionarykey,
+      index,
+      token: cssVarToTokenReference(token),
+    });
+  }, {});
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "open-props",
-  "version": "1.5.16",
+  "version": "1.6.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "open-props",
-      "version": "1.5.16",
+      "version": "1.6.8",
       "license": "MIT",
       "devDependencies": {
         "ava": "^3.15.0",

--- a/package.json
+++ b/package.json
@@ -171,6 +171,7 @@
     "./json": "./open-props.tokens.json",
     "./tokens": "./open-props.tokens.json",
     "./design-tokens": "./open-props.tokens.json",
+    "./style-dictionary-tokens": "./open-props.style-dictionary-tokens.json",
     "./postcss/brand": "./src/extra/brand.css",
     "./postcss/theme": "./src/extra/theme.css",
     "./postcss/theme-dark": "./src/extra/theme-dark.css",


### PR DESCRIPTION
This PR implements the `toStyleDictionary` script to generate a style dictionary compliant json file named `open-props.style-dictionary-tokens.json`

**Related to** #288 

It is a first draft to check if the approach works for you. In case I can continue and finalising it. E.g. ~~replace the reference to the CSS variables with the correct tokens (see below the sample for `--radius-conditional`)~~

The way I structured the tokens reflects the original naming convention.  [Here](https://gist.github.com/indaco/78840255ccb965321f00b54bb27ce43d) is the generated file for reference.

Below some examples:

#### colors

```json
{
  "color": {
    "yellow": {
      "0": {
        "value": "#fff9db",
        "type": "color"
      },
      "1": {
        "value": "#fff3bf",
        "type": "color"
      },
    ...
}
```

#### borders

##### sizes

```css
--border-size-{1-5}
```

turns into

```json
"border": {
    "size": {
      "1": {
        "value": "1px",
        "type": "border-width"
      },
      "2": {
        "value": "2px",
        "type": "border-width"
      },
     ...
    }
  }
```

##### radius

```css
--radius-{1-6}
--radius-conditional-{1-6}
```

turns into

```json
{
  "radius": {
    "1": {
      "value": "2px",
      "type": "border-radius"
    },
    "2": {
      "value": "5px",
      "type": "border-radius"
    },
    ....
     "conditional": {
        "1": {
          "value": "clamp(0px, calc(100vw - 100%) * 1e5, var(--radius-1))",
          "type": "border-radius"
        },
        "2": {
          "value": "clamp(0px, calc(100vw - 100%) * 1e5, var(--radius-2))",
          "type": "border-radius"
        },
      ...
    }
  }
}
```