### PR TITLE
fix(props.js): prefix mask individual props file names as all others

### DIFF
--- a/build/props.js
+++ b/build/props.js
@@ -59,8 +59,8 @@ const individual_colors_hsl = Object.keys(ColorsHSL)
   }), {})
 
 const individuals = {
-  'props.masks.edges.css': MaskEdges,
-  'props.masks.corner-cuts.css': MaskCornerCuts,
+  [`${pfx}props.masks.edges.css`]: MaskEdges,
+  [`${pfx}props.masks.corner-cuts.css`]: MaskCornerCuts,
 }
 
 // gen design tokens


### PR DESCRIPTION
I just noticed the 2 individual mask files where not prefixed on a custom prefix build.
This PR simply adds the prefix to these 2 files like for others.
