### PR TITLE
bookmarklet suggestion

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -26,6 +26,15 @@
 - [https://unpkg.com/open-props/open-props.figma-tokens.sync.json](https://unpkg.com/open-props/open-props.figma-tokens.sync.json) - Figma Design Tokens
 - [https://unpkg.com/open-props/open-props.style-dictionary-tokens.json](https://unpkg.com/open-props/open-props.style-dictionary-tokens.json) - Style Dictionary Tokens
 
+#### Bookmarklet
+
+```js
+javascript: (() => {
+  const href = "https://unpkg.com/open-props";
+  document.head.append(Object.assign(document.createElement("link"),{rel:"stylesheet",href}));
+})();
+```
+
 #### CLI
 - `npm run gen:op` - runs through `src/` js files and creates the PostCSS files in `src/`
 - `npm run gen:nowhere`  - creates a version of Open Props without the use of `:where()`


### PR DESCRIPTION
## why: 
to let people try op quickly in their browser (ide not required), 
and even to experiment on other people's websites. 
either by running it in the console 
or as a 1-click bookmark 
(bookmarks/bookmarklets also have fast keyboard access in chrome) 

## usage:

1. copy this code: 

```js
javascript: (() => {
  const href = "https://unpkg.com/open-props";
  document.head.append(Object.assign(document.createElement("link"),{rel:"stylesheet",href}));
})();
```

 * ([the value of `href` can be replaced with other CSS CDN URLs](https://unpkg.com/browse/open-props@latest/))

2. create a bookmark, paste that code you just copied into the URL field, and ideally name that bookmark with a unique name or a unique sequence of letters that's different from your other bookmarks. For me, "op" shows no other results when i search my bookmarks.

3. now you can do this in chrome:
 * mac: <kbd>command</kbd> + <kbd>L</kbd>, then type to search for the bookmark name, then hit enter --> open-props should now be temporarily added to the page!
 * pc: <kbd>Ctrl</kbd> + <kbd>L</kbd>, then type to search for the bookmark name, then hit enter --> open-props should now be temporarily added to the page!

and now you can play with op in the devtools Elements tab, or in Sources:

https://github.com/argyleink/open-props/assets/18131787/6a37181a-b391-47fc-b50f-218e1c86d3d5

basically same idea as https://github.com/argyleink/blingblingjs/issues/42 but for css