### PR TITLE
make figma-tokens plugin work again

### DIFF
--- a/build/to-figmatokens.js
+++ b/build/to-figmatokens.js
@@ -15,25 +15,25 @@ export const toFigmaTokens = props => {
       .map(hueName => hueName.toLowerCase())
     let isColor = colors.some(color => key.includes(color))
     
-    if      (isLength) meta.$type = 'sizing'
-    else if (isBorder) meta.$type = 'borderWidth'
-    else if (isRadius) meta.$type = 'borderRadius'
-    else if (isShadow) meta.$type = 'boxShadow'
-    else if (isColor)  meta.$type = 'color'
-    else               meta.$type = 'other'
+    if      (isLength) meta.type = 'sizing'
+    else if (isBorder) meta.type = 'borderWidth'
+    else if (isRadius) meta.type = 'borderRadius'
+    else if (isShadow) meta.type = 'boxShadow'
+    else if (isColor)  meta.type = 'color'
+    else               meta.type = 'other'
 
-    if (!(meta.$type in figmatokens)) figmatokens[meta.$type] = {}
+    if (!(meta.type in figmatokens)) figmatokens[meta.type] = {}
     
     if (isColor) {
       let color = /--(.+?)-/.exec(key)[1]
-      if (!(color in figmatokens[meta.$type])) figmatokens[meta.$type][color] = {}
-      figmatokens[meta.$type][color][key] = {
-        $value: token,
+      if (!(color in figmatokens[meta.type])) figmatokens[meta.type][color] = {}
+      figmatokens[meta.type][color][key] = {
+        value: token,
         ...meta,
       }
     } else {
-      figmatokens[meta.$type][key] = {
-        $value: token,
+      figmatokens[meta.type][key] = {
+        value: token,
         ...meta,
       }
     }


### PR DESCRIPTION
undo the `build/to-figmatokens.js` part of 327a70f (#392) 
to fix #455 and make op tokens work again in [figma-tokens plugin](https://github.com/tokens-studio/figma-plugin)

output looks correct again: (compare with the 2 screenshots in https://github.com/argyleink/open-props/issues/455#issue-2057942113) 

<img width="300" alt="value and type instead of $value and $type" src="https://github.com/argyleink/open-props/assets/18131787/c8282df8-4579-40f0-aec9-861d79ae475b">

<img width="357" alt="open props color tokens show colors again and are no longer just saying $value and $type" src="https://github.com/argyleink/open-props/assets/18131787/5fd408e0-80b6-411a-9b90-900c7ffb6cbd">
