### PR TITLE
Exporting `./supports.min.css`

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,6 +109,7 @@
     "./sizes": "./sizes.min.css",
     "./stone": "./stone.min.css",
     "./stone-hsl": "./stone-hsl.min.css",
+    "./supports": "./supports.min.css",
     "./teal": "./teal.min.css",
     "./teal-hsl": "./teal-hsl.min.css",
     "./violet": "./violet.min.css",


### PR DESCRIPTION
The file is listed on the docs page, but when importing it, `node` is unable to find it.