### PR TITLE
feat(media): add inverted colors custom media query

### DIFF
--- a/docsite/index.html
+++ b/docsite/index.html
@@ -3366,6 +3366,7 @@
               @custom-media --motionOK      (prefers-reduced-motion: no-preference);
               @custom-media --motionNotOK   (prefers-reduced-motion: reduce);
               
+              @custom-media --invertedColors  (inverted-colors: inverted);
               @custom-media --forcedColors  (forced-colors: active);
             </code></pre>
           </div>

--- a/src/props.media.css
+++ b/src/props.media.css
@@ -11,6 +11,7 @@
 @custom-media --highContrast  (prefers-contrast: more);
 @custom-media --lowContrast   (prefers-contrast: less);
 
+@custom-media --invertedColors  (inverted-colors: inverted);
 @custom-media --forcedColors  (forced-colors: active);
 
 @custom-media --portrait      (orientation: portrait);

--- a/src/props.media.js
+++ b/src/props.media.js
@@ -12,6 +12,7 @@ export const CustomMedia = {
   "--highContrast": "(prefers-contrast: more)",
   "--lowContrast": "(prefers-contrast: less)",
 
+  "--invertedColors": "(inverted-colors: inverted)",
   "--forcedColors": "(forced-colors: active)",
 
   "--portrait": "(orientation: portrait)",


### PR DESCRIPTION
Hi Adam,  

Browser support in not there yet, except for Safari, and Firefox behind flags, but I suggest we add the inverted colors MQ to the custom media queries list.

Updated:
- docsite
- props.media.css
- props.media.js

[Spec for reference](https://drafts.csswg.org/mediaqueries-5/#inverted)