### PR TITLE
Fix misconfigured Open Graph metadata

### DIFF
--- a/docsite/index.html
+++ b/docsite/index.html
@@ -4,11 +4,11 @@
     <meta charset="utf-8">
 
     <title>Open Props: sub-atomic styles</title>
-    <meta name="og:title" content="Open Props: sub-atomic styles">
+    <meta property="og:title" content="Open Props: sub-atomic styles">
     <meta name="twitter:title" content="Open Props: sub-atomic styles">
 
     <meta name="description" content="Open source CSS custom properties to help accelerate adaptive and consistent design. Available from a CDN or NPM, as CSS or Javascript.">
-    <meta name="og:description" content="Open source CSS custom properties to help accelerate adaptive and consistent design. Available from a CDN or NPM, as CSS or Javascript.">
+    <meta property="og:description" content="Open source CSS custom properties to help accelerate adaptive and consistent design. Available from a CDN or NPM, as CSS or Javascript.">
     <meta name="twitter:description" content="Open source CSS custom properties to help accelerate adaptive and consistent design. Available from a CDN or NPM, as CSS or Javascript.">
 
     <meta name="viewport" content="width=device-width, initial-scale=1">


### PR DESCRIPTION
I was testing my link card component with https://open-props.style/, and noticed that the website's Open Graph metadata is not correctly set. I fixed it accordingly.