### PR TITLE
durations.css – correct leap-year duration; introduce olympiad

### DIFF
--- a/src/extra/durations.css
+++ b/src/extra/durations.css
@@ -7,7 +7,8 @@
     --month:      calc( 30 * var(--day));
     --quarter:    calc( 13 * var(--week));
     --year:       calc(365 * var(--day));
-    --leap-year:  calc(  4 * var(--year));
+    --leap-year:  calc(366 * var(--day));
+    --olympiad:   calc(  4 * var(--year));
     --decade:     calc( 10 * var(--year));
     --generation: calc(  3 * var(--decade));
     --lifetime:   calc(  8 * var(--decade));


### PR DESCRIPTION
Hi there,

just noted an error in the durations. A leap year does not refer to a time span of four years, but to the length of the year where the leap day occurs, i.e. 366 days.

On the other hand, conveniently, there *is* a duration that describes a four-year timespan, an olympiad, which I introduced as a new property.

Hope this makes sense.