### PR TITLE
Fix the broken link for durations.css

### DIFF
--- a/docsite/index.html
+++ b/docsite/index.html
@@ -356,7 +356,7 @@
               </div>
             </dd>
             <dt>Extras</dt>
-            <dd class="size-chart" style="row-gap: var(--size-3)">
+            <dd class="size-chart">
               <div class="size"><strong>1.3</strong>kB</div>
               <div class="file">
                 <a href="https://unpkg.com/open-props/normalize.min.css">normalize.min.css</a> <a
@@ -390,6 +390,10 @@
               <div class="size"><strong>0.81</strong>kB</div>
               <div class="file">
                 <a href="https://unpkg.com/open-props/buttons.min.css">buttons.min.css</a> <a href="https://codepen.io/argyleink/pen/gOXbvjj"><small class="green-badge">demo</small></a>
+              </div>
+              <div class="size"><strong>1.4</strong>kB</div>
+              <div class="file">
+                <a href="https://github.com/argyleink/open-props/blob/main/src/extra/durations.css">durations.css</a>
               </div>
             </dd>
           </div>
@@ -456,11 +460,6 @@
                   </svg>
                   <span>etc...</span>
                 </div>
-              </div>
-
-              <div class="size"><strong>1.4</strong>kB</div>
-              <div class="file">
-                <a href="https://github.com/argyleink/open-props/blob/main/src/props.durations.css">durations.css</a>
               </div>
 
               <div class="size"><strong>0.2</strong>kB</div>

--- a/docsite/index.html
+++ b/docsite/index.html
@@ -356,7 +356,7 @@
               </div>
             </dd>
             <dt>Extras</dt>
-            <dd class="size-chart">
+            <dd class="size-chart" style="row-gap: var(--size-3)">
               <div class="size"><strong>1.3</strong>kB</div>
               <div class="file">
                 <a href="https://unpkg.com/open-props/normalize.min.css">normalize.min.css</a> <a
@@ -390,10 +390,6 @@
               <div class="size"><strong>0.81</strong>kB</div>
               <div class="file">
                 <a href="https://unpkg.com/open-props/buttons.min.css">buttons.min.css</a> <a href="https://codepen.io/argyleink/pen/gOXbvjj"><small class="green-badge">demo</small></a>
-              </div>
-              <div class="size"><strong>1.4</strong>kB</div>
-              <div class="file">
-                <a href="https://github.com/argyleink/open-props/blob/main/src/extra/durations.css">durations.css</a>
               </div>
             </dd>
           </div>
@@ -460,6 +456,11 @@
                   </svg>
                   <span>etc...</span>
                 </div>
+              </div>
+
+              <div class="size"><strong>1.4</strong>kB</div>
+              <div class="file">
+                <a href="https://github.com/argyleink/open-props/blob/main/src/extra/durations.css">durations.css</a>
               </div>
 
               <div class="size"><strong>0.2</strong>kB</div>


### PR DESCRIPTION
The link of https://github.com/argyleink/open-props/blob/main/src/props.durations.css in docsite is broken, PTAL.