### PR TITLE
Fix Gradient Docs

### DIFF
--- a/docsite/index.css
+++ b/docsite/index.css
@@ -1277,6 +1277,10 @@ pre[class*="language-"] {
     position: absolute;
   }
 
+  &.from-one:not(.tooltip, li)::before {
+      counter-reset: basic;
+  }
+
   & > *:not(.tooltip, li)::before {
     counter-increment: basic;
     content: counter(basic);

--- a/docsite/index.html
+++ b/docsite/index.html
@@ -1888,7 +1888,7 @@
           <h5>The Props</h5>
           <div class="var-examples">
             <pre class="language-css"><code>
-              --gradient-{0-30}
+              --gradient-{1-30}
             </code></pre>
           </div>
         </div>
@@ -1917,7 +1917,7 @@
       </div>
       <article class="just-stretch just-for-gap">
         <h4>Gradients</h4>
-        <div class="ui-gradients scroll-x-overflow count-em">
+        <div class="ui-gradients scroll-x-overflow count-em from-one">
           <span class="gradient-swatch" style="background-image: var(--gradient-1)"></span>
           <span class="gradient-swatch" style="background-image: var(--gradient-2)"></span>
           <span class="gradient-swatch" style="background-image: var(--gradient-3)"></span>


### PR DESCRIPTION
Docs site have a small mismatch between released behavior (`--gradient-1` through `--gradient-30`) and documented behavior (`--gradient-0` through `--gradient-29`). This fixes that. I added a `from-one` class that you can add to `count-em` lists to reset the counter to 1 rather than 0.

I'd recommend adding a `How to run the docs`. I eventually noticed the nested package.json and it was easy, but just a note in your README would help PR folks. I'd also recommend an .editorconfig or documentation in README about not trimming trailing space on save.