### PR TITLE
Add interpolate-size to normalize

### DIFF
--- a/css/packs/normalize/normalize.src.css
+++ b/css/packs/normalize/normalize.src.css
@@ -10,6 +10,8 @@
 	@supports (transition-timing-function: linear(0, 1)) {
 		--transition-focus: outline-offset 145ms var(--ease-spring-3);
 	}
+
+	interpolate-size: allow-keywords;
 }
 
 :where(:not(dialog)) {


### PR DESCRIPTION
If there are some gotchas with having this on the `:root`, let me know. Otherwise thought this would be neat to include out of the box. A downside may be that it doesn't have enough of a graceful fallback, idk.