### PR TITLE
Add text-decoration: none to .btn links for better styling

### DIFF
--- a/src/extra/buttons.css
+++ b/src/extra/buttons.css
@@ -101,6 +101,10 @@
   }
 }
 
+:where(.btn:is(a)) {
+  text-decoration: none;
+}
+
 /* adaptive indigo text */
 :where([type="submit"], form button:not([type],[disabled])) {
   --_text: var(--_accent, var(--link));


### PR DESCRIPTION
This PR adds `text-decoration: none` to the `.btn` class scoped specifically to links. This ensures that links styled as buttons have consistent appearance without requiring additional author styling.
The selector used is `:where(.btn:is(a))`, which emphasizes `.btn` as the primary styling hook.
