### PR TITLE
Fix: Ensure consistent fonts and correct usage of --font-monospace-code

### DIFF
--- a/docsite/index.html
+++ b/docsite/index.html
@@ -2246,7 +2246,7 @@
             <div class="font-family-grid">
             <details>
               <summary><code class="language-css">--font-monospace-code</code></summary>
-                <div style="font-family: var(--font-monospace)">
+                <div style="font-family: var(--font-monospace-code)">
                   <span>A</span><span>B</span><span>C</span><span>D</span><span>E</span><span>F</span><span>G</span><span>H</span><span>I</span><span>J</span><span>K</span><span>L</span><span>M</span><span>N</span><span>O</span><span>P</span><span>Q</span><span>R</span><span>S</span><span>T</span><span>U</span><span>V</span><span>W</span><span>X</span><span>Y</span><span>Z</span><span>a</span><span>b</span><span>c</span><span>d</span><span>e</span><span>f</span><span>g</span><span>h</span><span>i</span><span>j</span><span>k</span><span>l</span><span>m</span><span>n</span><span>o</span><span>p</span><span>q</span><span>r</span><span>s</span><span>t</span><span>u</span><span>v</span><span>w</span><span>x</span><span>y</span><span>z</span><span>1</span><span>2</span><span>3</span><span>4</span><span>5</span><span>6</span><span>7</span><span>8</span><span>9</span><span>0</span><span>+</span><span>=</span><span>!</span><span>@</span><span>#</span><span>%</span><span>$</span><span>%</span><span>^</span><span>&amp;</span>
                 </div>
               </details>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "open-props",
-  "version": "1.7.6",
+  "version": "1.7.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "open-props",
-      "version": "1.7.6",
+      "version": "1.7.10",
       "license": "MIT",
       "devDependencies": {
         "ava": "^3.15.0",

--- a/src/props.fonts.css
+++ b/src/props.fonts.css
@@ -7,7 +7,7 @@
   --font-classical-humanist: Optima, Candara, Noto Sans, source-sans-pro, sans-serif;
   --font-neo-grotesque: Inter, Roboto, Helvetica Neue, Arial Nova, Nimbus Sans, Arial, sans-serif;
   --font-monospace-slab-serif: Nimbus Mono PS, Courier New, monospace;
-  --font-monospace-code: Dank Mono,Operator Mono,Inconsolata,Fira Mono,ui-monospace,SF Mono,Monaco,Droid Sans Mono,Source Code Pro,Cascadia Code,Menlo,Consolas,DejaVu Sans Mono,monospace;
+  --font-monospace-code: Dank Mono,Operator Mono, Inconsolata, Fira Mono, ui-monospace, SF Mono, Monaco, Droid Sans Mono, Source Code Pro, Cascadia Code, Menlo, Consolas, DejaVu Sans Mono, monospace;
   --font-industrial: Bahnschrift, DIN Alternate, Franklin Gothic Medium, Nimbus Sans Narrow, sans-serif-condensed, sans-serif;
   --font-rounded-sans: ui-rounded, Hiragino Maru Gothic ProN, Quicksand, Comfortaa, Manjari, Arial Rounded MT, Arial Rounded MT Bold, Calibri, source-sans-pro, sans-serif;
   --font-slab-serif: Rockwell, Rockwell Nova, Roboto Slab, DejaVu Serif, Sitka Small, serif;


### PR DESCRIPTION
- Fixed inconsistent formatting in `props.fonts.css`, adding proper spacing to the `--font-monospace-code` prop value. 
- Corrected an issue in the doc where `font-family: var(--font-monospace);` was mistakenly used instead of `font-family: var(--font-monospace-code);` 