### PR TITLE
fix: add missing size-px props to style-dictionary-tokens

### DIFF
--- a/build/to-style-dictionary.js
+++ b/build/to-style-dictionary.js
@@ -2,6 +2,7 @@ import * as Colors from '../src/props.colors.js'
 
 // Mapping of CSS variable names to dictionary keys
 const dictionaryMap = {
+  "size-px":             "px",
   "size-relative":       "relative",
   "size-fluid":          "fluid",
   "size-header":         "header",


### PR DESCRIPTION
Style Dictionary Tokens miss size-px section in props

For example, try searching for the value "32px" at this link: https://unpkg.com/browse/open-props@1.7.10/open-props.style-dictionary-tokens.json other versions have this value.