### PR TITLE
Fix: restore newline so logo renders properly in README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,5 @@
 <div align="center">
+
 ![Open Props Logo](https://user-images.githubusercontent.com/1134620/141246730-7df4cf2a-6249-42ca-a01b-494c3ccddabe.png)
 
 ## Open Source CSS Variables


### PR DESCRIPTION
Restores the newline between the `<div align="center">` tag and the image link so the Open Props logo renders correctly on GitHub.  