### PR TITLE
Add text shadow props

### DIFF
--- a/docsite/index.html
+++ b/docsite/index.html
@@ -2467,6 +2467,7 @@
         <div class="var-examples">
           <pre class="language-css"><code>
               --shadow-{1-6}
+              --text-shadow-{1-6}
               --inner-shadow-{0-4}
             </code></pre>
         </div>
@@ -2480,6 +2481,14 @@
               &:hover {
                 box-shadow: var(--shadow-3);
               }
+            }
+          </code></pre>
+      </div>
+      <div>
+        <h5>Text Sample</h5>
+        <pre class="language-css"><code>
+            .hero-title {
+              text-shadow: var(--text-shadow-3);
             }
           </code></pre>
       </div>

--- a/open-props.resolver.json
+++ b/open-props.resolver.json
@@ -401,6 +401,188 @@
               ]
             }
           },
+          "text": {
+            "shadow-6": {
+              "$type": "shadow",
+              "$value": {
+                "color": {
+                  "colorSpace": "hsl",
+                  "components": [
+                    220,
+                    3,
+                    15
+                  ],
+                  "alpha": 0.08
+                },
+                "offsetX": {
+                  "value": 0,
+                  "unit": "px"
+                },
+                "offsetY": {
+                  "value": 0,
+                  "unit": "px"
+                },
+                "blur": {
+                  "value": 10,
+                  "unit": "px"
+                },
+                "spread": {
+                  "value": 0,
+                  "unit": "px"
+                }
+              }
+            },
+            "shadow-5": {
+              "$type": "shadow",
+              "$value": {
+                "color": {
+                  "colorSpace": "hsl",
+                  "components": [
+                    220,
+                    3,
+                    15
+                  ],
+                  "alpha": 0.07
+                },
+                "offsetX": {
+                  "value": 0,
+                  "unit": "px"
+                },
+                "offsetY": {
+                  "value": 0,
+                  "unit": "px"
+                },
+                "blur": {
+                  "value": 7,
+                  "unit": "px"
+                },
+                "spread": {
+                  "value": 0,
+                  "unit": "px"
+                }
+              }
+            },
+            "shadow-4": {
+              "$type": "shadow",
+              "$value": {
+                "color": {
+                  "colorSpace": "hsl",
+                  "components": [
+                    220,
+                    3,
+                    15
+                  ],
+                  "alpha": 0.06
+                },
+                "offsetX": {
+                  "value": 0,
+                  "unit": "px"
+                },
+                "offsetY": {
+                  "value": 0,
+                  "unit": "px"
+                },
+                "blur": {
+                  "value": 5,
+                  "unit": "px"
+                },
+                "spread": {
+                  "value": 0,
+                  "unit": "px"
+                }
+              }
+            },
+            "shadow-3": {
+              "$type": "shadow",
+              "$value": {
+                "color": {
+                  "colorSpace": "hsl",
+                  "components": [
+                    220,
+                    3,
+                    15
+                  ],
+                  "alpha": 0.05
+                },
+                "offsetX": {
+                  "value": 0,
+                  "unit": "px"
+                },
+                "offsetY": {
+                  "value": 0,
+                  "unit": "px"
+                },
+                "blur": {
+                  "value": 3,
+                  "unit": "px"
+                },
+                "spread": {
+                  "value": 0,
+                  "unit": "px"
+                }
+              }
+            },
+            "shadow-2": {
+              "$type": "shadow",
+              "$value": {
+                "color": {
+                  "colorSpace": "hsl",
+                  "components": [
+                    220,
+                    3,
+                    15
+                  ],
+                  "alpha": 0.04
+                },
+                "offsetX": {
+                  "value": 0,
+                  "unit": "px"
+                },
+                "offsetY": {
+                  "value": 0,
+                  "unit": "px"
+                },
+                "blur": {
+                  "value": 2,
+                  "unit": "px"
+                },
+                "spread": {
+                  "value": 0,
+                  "unit": "px"
+                }
+              }
+            },
+            "shadow-1": {
+              "$type": "shadow",
+              "$value": {
+                "color": {
+                  "colorSpace": "hsl",
+                  "components": [
+                    220,
+                    3,
+                    15
+                  ],
+                  "alpha": 0.03
+                },
+                "offsetX": {
+                  "value": 0,
+                  "unit": "px"
+                },
+                "offsetY": {
+                  "value": 0,
+                  "unit": "px"
+                },
+                "blur": {
+                  "value": 1,
+                  "unit": "px"
+                },
+                "spread": {
+                  "value": 0,
+                  "unit": "px"
+                }
+              }
+            }
+          },
           "shadow": {
             "1": {
               "$type": "shadow",

--- a/src/props.shadows.css
+++ b/src/props.shadows.css
@@ -43,6 +43,12 @@
     0 22px 18px -2px hsl(var(--shadow-color) / var(--shadow-strength-6)),
     0 41px 33px -2px hsl(var(--shadow-color) / var(--shadow-strength-7)),
     0 100px 80px -2px hsl(var(--shadow-color) / var(--shadow-strength-8));
+  --text-shadow-1: 0 0 1px hsl(var(--shadow-color) / var(--shadow-strength-3));
+  --text-shadow-2: 0 0 2px hsl(var(--shadow-color) / var(--shadow-strength-4));
+  --text-shadow-3: 0 0 3px hsl(var(--shadow-color) / var(--shadow-strength-5));
+  --text-shadow-4: 0 0 5px hsl(var(--shadow-color) / var(--shadow-strength-6));
+  --text-shadow-5: 0 0 7px hsl(var(--shadow-color) / var(--shadow-strength-7));
+  --text-shadow-6: 0 0 10px hsl(var(--shadow-color) / var(--shadow-strength-8));
   --inner-shadow-0: inset 0 0 0 1px hsl(var(--shadow-color) / var(--shadow-strength-10));
   --inner-shadow-1: inset 0 1px 2px 0 hsl(var(--shadow-color) / var(--shadow-strength-10)), var(--inner-shadow-highlight);
   --inner-shadow-2: inset 0 1px 4px 0 hsl(var(--shadow-color) / var(--shadow-strength-10)), var(--inner-shadow-highlight);

--- a/src/props.shadows.dark.css
+++ b/src/props.shadows.dark.css
@@ -41,6 +41,12 @@
     0 22px 18px -2px hsl(var(--shadow-color) / var(--shadow-strength-6)),
     0 41px 33px -2px hsl(var(--shadow-color) / var(--shadow-strength-7)),
     0 100px 80px -2px hsl(var(--shadow-color) / var(--shadow-strength-8));
+  --text-shadow-1: 0 0 1px hsl(var(--shadow-color) / var(--shadow-strength-3));
+  --text-shadow-2: 0 0 2px hsl(var(--shadow-color) / var(--shadow-strength-4));
+  --text-shadow-3: 0 0 3px hsl(var(--shadow-color) / var(--shadow-strength-5));
+  --text-shadow-4: 0 0 5px hsl(var(--shadow-color) / var(--shadow-strength-6));
+  --text-shadow-5: 0 0 7px hsl(var(--shadow-color) / var(--shadow-strength-7));
+  --text-shadow-6: 0 0 10px hsl(var(--shadow-color) / var(--shadow-strength-8));
   --inner-shadow-0: inset 0 0 0 1px hsl(var(--shadow-color) / var(--shadow-strength-10));
   --inner-shadow-1: inset 0 1px 2px 0 hsl(var(--shadow-color) / var(--shadow-strength-10)), var(--inner-shadow-highlight);
   --inner-shadow-2: inset 0 1px 4px 0 hsl(var(--shadow-color) / var(--shadow-strength-10)), var(--inner-shadow-highlight);

--- a/src/props.shadows.js
+++ b/src/props.shadows.js
@@ -48,6 +48,13 @@ const Shadows = {
     0 41px 33px -2px hsl(var(--shadow-color) / var(--shadow-strength-7)),
     0 100px 80px -2px hsl(var(--shadow-color) / var(--shadow-strength-8))`,
 
+  '--text-shadow-1': '0 0 1px hsl(var(--shadow-color) / var(--shadow-strength-3))',
+  '--text-shadow-2': '0 0 2px hsl(var(--shadow-color) / var(--shadow-strength-4))',
+  '--text-shadow-3': '0 0 3px hsl(var(--shadow-color) / var(--shadow-strength-5))',
+  '--text-shadow-4': '0 0 5px hsl(var(--shadow-color) / var(--shadow-strength-6))',
+  '--text-shadow-5': '0 0 7px hsl(var(--shadow-color) / var(--shadow-strength-7))',
+  '--text-shadow-6': '0 0 10px hsl(var(--shadow-color) / var(--shadow-strength-8))',
+
   '--inner-shadow-0': 'inset 0 0 0 1px hsl(var(--shadow-color) / var(--shadow-strength-10))',
   '--inner-shadow-1': 'inset 0 1px 2px 0 hsl(var(--shadow-color) / var(--shadow-strength-10)), var(--inner-shadow-highlight)',
   '--inner-shadow-2': 'inset 0 1px 4px 0 hsl(var(--shadow-color) / var(--shadow-strength-10)), var(--inner-shadow-highlight)',

--- a/src/props.shadows.light.css
+++ b/src/props.shadows.light.css
@@ -41,6 +41,12 @@
     0 22px 18px -2px hsl(var(--shadow-color) / var(--shadow-strength-6)),
     0 41px 33px -2px hsl(var(--shadow-color) / var(--shadow-strength-7)),
     0 100px 80px -2px hsl(var(--shadow-color) / var(--shadow-strength-8));
+  --text-shadow-1: 0 0 1px hsl(var(--shadow-color) / var(--shadow-strength-3));
+  --text-shadow-2: 0 0 2px hsl(var(--shadow-color) / var(--shadow-strength-4));
+  --text-shadow-3: 0 0 3px hsl(var(--shadow-color) / var(--shadow-strength-5));
+  --text-shadow-4: 0 0 5px hsl(var(--shadow-color) / var(--shadow-strength-6));
+  --text-shadow-5: 0 0 7px hsl(var(--shadow-color) / var(--shadow-strength-7));
+  --text-shadow-6: 0 0 10px hsl(var(--shadow-color) / var(--shadow-strength-8));
   --inner-shadow-0: inset 0 0 0 1px hsl(var(--shadow-color) / var(--shadow-strength-10));
   --inner-shadow-1: inset 0 1px 2px 0 hsl(var(--shadow-color) / var(--shadow-strength-10)), var(--inner-shadow-highlight);
   --inner-shadow-2: inset 0 1px 4px 0 hsl(var(--shadow-color) / var(--shadow-strength-10)), var(--inner-shadow-highlight);

--- a/test/basic.test.cjs
+++ b/test/basic.test.cjs
@@ -4,7 +4,7 @@ const OpenProps = require('../dist/open-props.cjs')
 const OPtokens = require('../open-props.tokens.json')
 
 test('Should have an all included import', t => {
-  t.is(Object.keys(OpenProps).length, 1830)
+  t.is(Object.keys(OpenProps).length, 1842)
 })
 
 test('Import should have animations', async t => {
@@ -26,6 +26,13 @@ test('Import should have colors', async t => {
 test('Import should have palette', async t => {
   t.assert(Object.keys(OpenProps).includes('--color-1'))
   t.assert(OpenProps.color1)
+})
+
+test('Import should have text shadows', t => {
+  for (let step = 1; step <= 6; step++) {
+    t.assert(Object.keys(OpenProps).includes(`--text-shadow-${step}`))
+    t.assert(OpenProps[`textShadow${step}`])
+  }
 })
 
 test('JSON Import should have colors', async t => {


### PR DESCRIPTION
## What changed

- add a six-step `--text-shadow-{1-6}` scale
- include the new props in adaptive, light, dark, JavaScript, and resolver outputs
- document text-shadow usage on the project website
- add regression coverage for CSS and camel-cased JavaScript exports

Closes #588
